### PR TITLE
GitHub Actions workflow to publish releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Publish release
 on:
   push:
     tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs: {}
 
 jobs:
   build:
@@ -44,6 +46,7 @@ jobs:
         echo "::set-output name=zipfile::$(cat build/zipfile.txt)"
         echo "::set-output name=zipname::$(basename "$(cat build/zipfile.txt)")"
     - name: Check consistency between tag name and version
+      if: success() && github.event_name == 'push'
       env:
         tag: ${{ github.ref }}
         version: ${{ steps.get-metadata.outputs.version }}
@@ -59,8 +62,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
+        tag_name: v${{ steps.get-metadata.outputs.version }}
+        release_name: v${{ steps.get-metadata.outputs.version }}
         body_path: ./build/latest_changelog.md
     - name: Upload asset for GitHub release
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,17 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    # Setup cache
+    - name: Setup cache for Gradle and dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: "gradle-\
+          ${{runner.os}}-\
+          ${{hashFiles('gradle/wrapper/gradle-wrapper.properties')}}-\
+          ${{hashFiles('**/*.gradle.kts')}}"
     # Build
     - name: Build plugin
       id: gradle-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build release
+name: Publish release
 
 on:
   push:
@@ -7,10 +7,8 @@ on:
 jobs:
   build:
 
-    name: Build plugin
+    name: Publish release
     runs-on: ubuntu-latest
-    outputs:
-      zip-name: ${{ steps.get-zip-name.outputs.zip-name }}
 
     steps:
     # Setup environment
@@ -24,23 +22,7 @@ jobs:
     - name: Build plugin
       id: gradle-build
       run: ./gradlew verifyPlugin build
-    - name: Get changelog
-      run: |
-        ./gradlew getChangelog --console=plain -q --no-header --unreleased \
-          > latest_changelog.md
     # Upload artifacts
-    - name: Upload build result
-      uses: actions/upload-artifact@v2
-      with:
-        name: build-result
-        path: build/distributions/
-        if-no-files-found: error
-    - name: Upload changelog
-      uses: actions/upload-artifact@v2
-      with:
-        name: build-result
-        path: ./latest_changelog.md
-        if-no-files-found: error
     - name: Upload build reports
       if: steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure'
       uses: actions/upload-artifact@v2
@@ -48,24 +30,22 @@ jobs:
         name: build-reports
         path: build/reports/
         if-no-files-found: ignore
-    # Get name of zip file
+    - name: Upload build result
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-result
+        path: build/distributions/
+        if-no-files-found: error
+    # Create GitHub release
+    - name: Get changelog
+      run: |
+        ./gradlew getChangelog --console=plain -q --no-header --unreleased \
+          > latest_changelog.md
     - name: Get name of ZIP
       id: get-zip-name
       run: |
-        echo "::set-output name=zip-name::$(basename build/distributions/*.zip)"
-
-  create-release:
-
-    name: Create GitHub release
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-    - name: Download build result
-      uses: actions/download-artifact@v2
-      with:
-        name: build-result
-    - name: Create Release
+        echo "::set-output name=zip-name::$(basename ./build/distributions/*.zip)"
+    - name: Create GitHub release
       uses: actions/create-release@v1
       id: create_release
       env:
@@ -74,36 +54,17 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
         body_path: ./latest_changelog.md
-    - name: Upload Release Asset
+    - name: Upload asset for GitHub release
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./${{ needs.build.outputs.zip-name }}
-        asset_name: ${{ needs.build.outputs.zip-name }}
+        asset_path: ./build/distributions/${{ steps.get-zip-name.outputs.zip-name }}
+        asset_name: ${{ steps.get-zip-name.outputs.zip-name }}
         asset_content_type: application/zip
-
-  upload-to-marketplace:
-
-    name: Upload to JetBrains Marketplace
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-    - name: Download build result
-      uses: actions/download-artifact@v2
-      with:
-        name: build-result
-    - name: Upload plugin to JetBrains Marketplace
-      # https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html
+    # Upload to JetBrains Marketplace
+    - name: Upload to JetBrains Marketplace
       env:
-        zip_name: ./${{ needs.build.outputs.zip-name }}
-        jetbrains_token: ${{ secrets.JETBRAINS_TOKEN }}
-      run: |
-        [[ $(curl -i \
-            --header "Authorization: Bearer ${jetbrains_token}" \
-            -F xmlId=nix-idea \
-            -F file="@${zip_name}" \
-            https://plugins.jetbrains.com/plugin/uploadPlugin \
-          -o /dev/stderr -w "%{http_code}") == 2* ]]
+        JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
+      run: ./gradlew publishPlugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     # Build
     - name: Build plugin
       id: gradle-build
-      run: ./gradlew verifyPlugin build
+      run: ./gradlew verifyPlugin build writeMetadataFiles
     # Upload artifacts
     - name: Upload build reports
       if: steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure'
@@ -36,32 +36,40 @@ jobs:
         name: build-result
         path: build/distributions/
         if-no-files-found: error
+    # Get metadata
+    - name: Get metadata
+      id: get-metadata
+      run: |
+        echo "::set-output name=version::$(cat build/version.txt)"
+        echo "::set-output name=zipfile::$(cat build/zipfile.txt)"
+        echo "::set-output name=zipname::$(basename "$(cat build/zipfile.txt)")"
+    - name: Check consistency between tag name and version
+      env:
+        tag: ${{ github.ref }}
+        version: ${{ steps.get-metadata.outputs.version }}
+      run: |
+        if [ "$tag" != "v$version" -a "$tag" != "refs/tags/v$version" ]; then
+          echo "Tag '$tag' does not match version '$version'." >&2
+          exit 1
+        fi
     # Create GitHub release
-    - name: Get changelog
-      run: |
-        ./gradlew getChangelog --console=plain -q --no-header --unreleased \
-          > latest_changelog.md
-    - name: Get name of ZIP
-      id: get-zip-name
-      run: |
-        echo "::set-output name=zip-name::$(basename ./build/distributions/*.zip)"
     - name: Create GitHub release
       uses: actions/create-release@v1
-      id: create_release
+      id: create-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
-        body_path: ./latest_changelog.md
+        body_path: ./build/latest_changelog.md
     - name: Upload asset for GitHub release
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./build/distributions/${{ steps.get-zip-name.outputs.zip-name }}
-        asset_name: ${{ steps.get-zip-name.outputs.zip-name }}
+        upload_url: ${{ steps.create-release.outputs.upload_url }}
+        asset_path: ${{ steps.get-metadata.outputs.zipfile }}
+        asset_name: ${{ steps.get-metadata.outputs.zipname }}
         asset_content_type: application/zip
     # Upload to JetBrains Marketplace
     - name: Upload to JetBrains Marketplace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Build release
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+jobs:
+  build:
+
+    name: Build plugin
+    runs-on: ubuntu-latest
+    outputs:
+      zip-name: ${{ steps.get-zip-name.outputs.zip-name }}
+
+    steps:
+    # Setup environment
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    # Build
+    - name: Build plugin
+      id: gradle-build
+      run: ./gradlew verifyPlugin build
+    - name: Get changelog
+      run: |
+        ./gradlew getChangelog --console=plain -q --no-header --unreleased \
+          > latest_changelog.md
+    # Upload artifacts
+    - name: Upload build result
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-result
+        path: build/distributions/
+        if-no-files-found: error
+    - name: Upload changelog
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-result
+        path: ./latest_changelog.md
+        if-no-files-found: error
+    - name: Upload build reports
+      if: steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure'
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-reports
+        path: build/reports/
+        if-no-files-found: ignore
+    # Get name of zip file
+    - name: Get name of ZIP
+      id: get-zip-name
+      run: |
+        echo "::set-output name=zip-name::$(basename build/distributions/*.zip)"
+
+  create-release:
+
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Download build result
+      uses: actions/download-artifact@v2
+      with:
+        name: build-result
+    - name: Create Release
+      uses: actions/create-release@v1
+      id: create_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        body_path: ./latest_changelog.md
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./${{ needs.build.outputs.zip-name }}
+        asset_name: ${{ needs.build.outputs.zip-name }}
+        asset_content_type: application/zip
+
+  upload-to-marketplace:
+
+    name: Upload to JetBrains Marketplace
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Download build result
+      uses: actions/download-artifact@v2
+      with:
+        name: build-result
+    - name: Upload plugin to JetBrains Marketplace
+      # https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html
+      env:
+        zip_name: ./${{ needs.build.outputs.zip-name }}
+        jetbrains_token: ${{ secrets.JETBRAINS_TOKEN }}
+      run: |
+        [[ $(curl -i \
+            --header "Authorization: Bearer ${jetbrains_token}" \
+            -F xmlId=nix-idea \
+            -F file="@${zip_name}" \
+            https://plugins.jetbrains.com/plugin/uploadPlugin \
+          -o /dev/stderr -w "%{http_code}") == 2* ]]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,8 +54,6 @@ grammarKit {
 tasks {
 
     task<GenerateLexer>("generateNixLexer") {
-        println("Generating lexer")
-
         source = "src/main/lang/Nix.flex"
         targetDir = "src/gen/java/org/nixos/idea/lang"
         targetClass = "NixLexer"
@@ -63,8 +61,6 @@ tasks {
     }
 
     task<GenerateParser>("generateNixParser") {
-        println("Generating parser")
-
         source = "src/main/lang/Nix.bnf"
         targetRoot = "src/gen/java"
         pathToParser = "/org/nixos/idea/lang/NixParser"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,15 @@ grammarKit {
 
 tasks {
 
+    task("writeMetadataFiles") {
+        outputs.upToDateWhen { false }
+        doLast {
+            project.buildDir.resolve("version.txt").writeText(pluginVersion)
+            project.buildDir.resolve("zipfile.txt").writeText(buildPlugin.get().archiveFile.get().toString())
+            project.buildDir.resolve("latest_changelog.md").writeText(changelog.getLatest().toText())
+        }
+    }
+
     task<GenerateLexer>("generateNixLexer") {
         source = "src/main/lang/Nix.flex"
         targetDir = "src/gen/java/org/nixos/idea/lang"
@@ -113,7 +122,7 @@ tasks {
         // Get the latest available change notes from the changelog file
         changeNotes(
                 closure {
-                    changelog.getUnreleased().toHTML()
+                    changelog.getLatest().toHTML()
                 }
         )
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,14 +113,13 @@ tasks {
         // Get the latest available change notes from the changelog file
         changeNotes(
                 closure {
-                    changelog.getLatest().toHTML()
+                    changelog.getUnreleased().toHTML()
                 }
         )
     }
 
     publishPlugin {
-        dependsOn("patchChangelog")
-        token(System.getenv("PUBLISH_TOKEN"))
+        token(System.getenv("JETBRAINS_TOKEN"))
         channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
     }
 


### PR DESCRIPTION
I created a GitHub Actions workflow to publish new releases. It can be triggered manually or by pushing a tag. You can look at a few builds here:

* [Triggered by a tag](https://github.com/JojOatXGME/nix-idea/runs/1217764353)
* [Triggered by a tag which does not match the version](https://github.com/JojOatXGME/nix-idea/runs/1217764335)
* [Manually triggered in UI of GitHub Actions](https://github.com/JojOatXGME/nix-idea/runs/1221759356)

The generated release looks like this: [Generated release on GitHub](https://github.com/JojOatXGME/nix-idea/releases/tag/v0.3.0.0)

I haven't tested the publication to the JetBrains Marketplace. I wasn't sure if it is OK to release a new version under another name just to test the publication process. It should work after adding [a permanent token](https://plugins.jetbrains.com/author/me/tokens) as secret `JETBRAINS_TOKEN` to the GitHub repository.

Note that after releasing a new version, the workflow does not (yet) bump the version number or update the `CHANGELOG.md`. If you want such feature, we can talk about it. There might be some pitfalls because other persons can push to the repository while the job is running.