### PR TITLE
Separate workflows for creating release and publishing to JetBrains

### DIFF
--- a/.github/workflows/publish-to-jetbrains.yml
+++ b/.github/workflows/publish-to-jetbrains.yml
@@ -1,0 +1,47 @@
+name: Publish to JetBrains Marketplace
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  publish:
+
+    name: Publish release
+    runs-on: ubuntu-latest
+
+    steps:
+    # Setup environment
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    # Setup cache
+    - name: Setup cache for Gradle and dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: "gradle-\
+          ${{runner.os}}-\
+          ${{hashFiles('gradle/wrapper/gradle-wrapper.properties')}}-\
+          ${{hashFiles('**/*.gradle.kts')}}"
+    # Build and publish
+    - name: Build and publish plugin
+      id: gradle-build
+      env:
+        JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
+      run: ./gradlew --stacktrace publishPlugin
+    # Upload artifacts
+    - name: Upload build reports
+      if: steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure'
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-reports
+        path: build/reports/
+        if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish release
+name: Prepare Release
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    name: Publish release
+    name: Create draft for GitHub release
     runs-on: ubuntu-latest
 
     steps:
@@ -66,8 +66,8 @@ jobs:
           echo "Tag '$tag' does not match version '$version'." >&2
           exit 1
         fi
-    # Create GitHub release
-    - name: Create GitHub release
+    # Create GitHub release draft
+    - name: Create GitHub release draft
       uses: actions/create-release@v1
       id: create-release
       env:
@@ -76,6 +76,7 @@ jobs:
         tag_name: v${{ steps.get-metadata.outputs.version }}
         release_name: v${{ steps.get-metadata.outputs.version }}
         body_path: ./build/latest_changelog.md
+        draft: true
     - name: Upload asset for GitHub release
       uses: actions/upload-release-asset@v1
       env:
@@ -85,8 +86,3 @@ jobs:
         asset_path: ${{ steps.get-metadata.outputs.zipfile }}
         asset_name: ${{ steps.get-metadata.outputs.zipname }}
         asset_content_type: application/zip
-    # Upload to JetBrains Marketplace
-    - name: Upload to JetBrains Marketplace
-      env:
-        JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
-      run: ./gradlew --stacktrace publishPlugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,17 @@ jobs:
 
     steps:
     # Remove old release drafts
-    # Copied from https://github.com/JetBrains/intellij-platform-plugin-template
     - name: Remove old release drafts
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
-          | tr '\r\n' ' ' \
-          | jq '.[] | select(.draft == true) | .id' \
-          | xargs -I '{}' \
-        curl -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases/{}
+      uses: actions/github-script@v3
+      with:
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const response = await github.repos.listReleases({owner, repo});
+          for (const draft of response.data.filter(r => r.draft)) {
+            core.info(`Delete draft for '${draft.name}' (${draft.id})`);
+            await github.repos.deleteRelease({owner, repo, release_id: draft.id});
+          }
     # Setup environment
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,28 @@ name: Prepare Release
 
 on:
   push:
-    tags: [ 'v*' ]
+    branches: [ 'master' ]
   workflow_dispatch:
     inputs: {}
 
 jobs:
   build:
 
-    name: Create draft for GitHub release
+    name: Update drafts for a GitHub release
     runs-on: ubuntu-latest
 
     steps:
+    # Remove old release drafts
+    # Copied from https://github.com/JetBrains/intellij-platform-plugin-template
+    - name: Remove old release drafts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
+          | tr '\r\n' ' ' \
+          | jq '.[] | select(.draft == true) | .id' \
+          | xargs -I '{}' \
+        curl -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases/{}
     # Setup environment
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -56,14 +67,17 @@ jobs:
         echo "::set-output name=version::$(cat build/version.txt)"
         echo "::set-output name=zipfile::$(cat build/zipfile.txt)"
         echo "::set-output name=zipname::$(basename "$(cat build/zipfile.txt)")"
-    - name: Check consistency between tag name and version
-      if: success() && github.event_name == 'push'
+    # Fail job if the release tag already exists and points to a different commit
+    - name: Check release tag
       env:
-        tag: ${{ github.ref }}
-        version: ${{ steps.get-metadata.outputs.version }}
+        TAG_NAME: v${{ steps.get-metadata.outputs.version }}
+        COMMITISH: ${{ github.sha }}
       run: |
-        if [ "$tag" != "v$version" -a "$tag" != "refs/tags/v$version" ]; then
-          echo "Tag '$tag' does not match version '$version'." >&2
+        if \
+          git fetch --depth=1 origin tag "$TAG_NAME" && \
+          [ "$(git rev-parse "$TAG_NAME")" != "$(git rev-parse "$COMMITISH")" ]
+        then
+          echo "::error::Tag '$TAG_NAME' already exists but points to a different commit"
           exit 1
         fi
     # Create GitHub release draft


### PR DESCRIPTION
This is an update for the release workflow(s). It addresses the issue of pull request #16 that you cannot re-run the step which publishes the release to *JetBrains Marketplace*. After this branch is merged, you can trigger the workflow *Publish to JetBrains Marketplace* manually without creating a new release.

I also changed the release process because releases created by *GitHub Actions* will not trigger any workflow. This means creating a release with GitHub Actions would not trigger the workflow which publishes the release to *JetBrains Marketplace*. To overcome this issue, the workflow *Publish release* is renamed to *Prepare Release* and will create drafts instead of actual releases. It will create a new draft whenever the *master* branch is updated. When you publish the draft as a release, GitHub tiggers the second workflow which publishes the release to *JetBrains Marketplace*.

Note that you shouldn't usually trigger *Publish to JetBrains Marketplace* manually. You should only trigger it manually if something was going wrong previously. If you want to publish a new version, you should create a new release instead.

As a caveat of this change, the binary for *JetBrains Marketplace* is build independently from the binary for the GitHub release. Since the build is not fully reproducible, both binaries may not be exactly the same. Anyway, both are build from the same sources.

PS: I got some inspiration from [JetBrains/intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template). While looking at this template, I already worked at some more improvments like bumping the version after the release. However, I wanted to fix the issue about the publication process first.