### PR TITLE
Reset plugin XML id to commit 6581d478e3c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
-## [Unreleased] 
+## [Unreleased]
+### Fixed
+- Change ID of plugin back from `org.nixos.idea` in version 0.3.0.0 to
+  `nix-idea` from earlier versions. The different ID of version 0.3.0.0
+  causes *IntelliJ* and *JetBrains Marketplace* to treat version 0.3.0.0
+  as a different plugin instead of another version of the same plugin.
+  **Note that if you installed version 0.3.0.0 manually from the ZIP
+  file, you should uninstall it when updating to a new version.**
+## [0.3.0.0]
 ### Changed
 - Update project to build for recent IJ versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = org.nixos.idea
 pluginName = NixIDEA
-pluginVersion = 0.3.0.0
+pluginVersion = 0.3.0.3
 pluginSinceBuild = 193
 pluginUntilBuild = 202.*
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
 
-    <id>org.nixos.idea</id>
+    <id>nix-idea</id>
     <name>NixIDEA</name>
     <vendor>NixOS</vendor>
 


### PR DESCRIPTION
Change the plugin XML ID back to the same ID used for previous releases on the Marketplace. This change actually affacts the plugin and should probably be released as a new version.

EDIT: If you want to release a new version, you have to wait until job **Prepare Release / Update drafts for a GitHub release** on the master branch has succeeded. You should then find a release draft on GitHub ready to be released.

EDIT: The ID has been changed from `nix-idea` to `org.nixos.idea` in 6581d478e3c...ea2c5c8dc18. You can inspect the ID of earlier releases at https://plugins.jetbrains.com/plugin/8607-nixidea/versions/stable/41592.