### PR TITLE
Update plugins to stop using Bintray

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
     // Java support
     id("java")
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "0.6.5"
+    id("org.jetbrains.intellij") version "0.7.3"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "0.6.2"
     // grammarkit - read more: https://github.com/JetBrains/gradle-grammar-kit-plugin
-    id("org.jetbrains.grammarkit") version "2020.3.2"
+    id("org.jetbrains.grammarkit") version "2021.1.2"
 }
 
 // Import variables from gradle.properties file


### PR DESCRIPTION
Update Gradle plugins `org.jetbrains.intellij` and `org.jetbrains.grammarkit`. The previous versions have used the services from Bintray which have been shut down on May 1, 2021.

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/