### PR TITLE
Add support for IDEA 2022.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,8 @@
 ## [Unreleased]
 ### Added
 
-### Changed
+- Support for IDEA 2022.1
 
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 ## [0.4.0.2]
 ### Added
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
     // Java support
     id("java")
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.3.1"
+    id("org.jetbrains.intellij") version "1.5.2"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // grammarkit - read more: https://github.com/JetBrains/gradle-grammar-kit-plugin
-    id("org.jetbrains.grammarkit") version "2021.2.1"
+    id("org.jetbrains.grammarkit") version "2021.2.2"
 }
 
 // Import variables from gradle.properties file

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = org.nixos.idea
 pluginName = NixIDEA
 pluginVersion = 0.4.0.3
 pluginSinceBuild = 211
-pluginUntilBuild = 213.*
+pluginUntilBuild = 221.*
 
 platformType = IC
 platformVersion = 2021.1.3


### PR DESCRIPTION
I declared support for IDEA 2022.1 since the release candidate has recently been released.
https://blog.jetbrains.com/idea/2022/04/intellij-idea-2022-1-release-candidate/

I also updated two Gradle plugins because they fixed incompatibilities with IDEA 2022.1.

> Add util_rt.jar to the classpath of run-like tasks for 2022.1+ compatibility
> — https://github.com/JetBrains/gradle-intellij-plugin/releases/tag/v1.5.2

> Add util_rt.jar into GrammarKit call classpath
> — https://github.com/JetBrains/gradle-grammar-kit-plugin/releases/tag/v2021.2.2

Note that these incompatibilities only cause an issue if you change the `platformVersion` in the `gradle.properties` to 2022.1. This means they are not critical, but better fixing it now than later.