### PR TITLE
Add workflow to bump version number

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,106 @@
+name: Bump Version
+
+on:
+  release:
+    types: [ released ]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Use release notes of'
+        type: string
+        required: false
+
+jobs:
+  bump-version:
+
+    name: Bump version and update changelog
+    runs-on: ubuntu-latest
+
+    steps:
+    # Setup environment
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: adopt
+    # Fail if the release was not triggered from the master branch
+    - name: Verify branch
+      if: github.event_name == 'release'
+      run: |
+        if \
+          git fetch --depth=1 origin refs/heads/master && \
+          [ "$(git show-ref -s refs/heads/master)" != "$(git show-ref -s HEAD)" ]
+        then
+          msg="The release does not point to the master branch. This means the"
+          msg="$msg branch has been updated after the release, or the release"
+          msg="$msg was created on a different branch. Please trigger this"
+          msg="$msg workflow manually on the correct branch."
+          echo "::error::$msg"
+          exit 1
+        fi
+    # Setup cache
+    - name: Setup cache for Gradle and dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: "gradle-\
+          ${{runner.os}}-\
+          ${{hashFiles('gradle/wrapper/gradle-wrapper.properties')}}-\
+          ${{hashFiles('gradle.properties', '**/*.gradle.kts')}}"
+    # Update files
+    - name: Obtain release notes
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs');
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          let releaseNote;
+
+          if (context.eventName === 'release') {
+            releaseNote = context.payload.release.body;
+          }
+          else if (context.payload.inputs.release_tag) {
+            const tag = context.payload.inputs.release_tag;
+            try {
+              const response = await github.rest.repos.getReleaseByTag({owner, repo, tag});
+              releaseNote = response.data.body;
+            }
+            catch (e) {
+              if (e.status === 404) {
+                core.setFailed(`No release with tag '${tag}' has been found.`);
+                return;
+              }
+              else {
+                throw e;
+              }
+            }
+          }
+          else {
+            const response = await github.rest.repos.getLatestRelease({owner, repo});
+            releaseNote = response.data.body;
+          }
+
+          core.info(`Release notes:\n${releaseNote}`);
+          fs.writeFileSync('release_note.md', releaseNote, { encoding: 'utf8', flag: 'wx' });
+    - name: Update files with Gradle
+      run: ./gradlew --stacktrace metadata patchChangelog --release-note="$(<release_note.md)" bumpVersion
+    # Commit and push
+    - name: Commit files
+      run: |
+        version="$(cat build/metadata/version.txt)"
+        git -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+          commit -am "Bump version after releasing v$version"
+    - name: Push changes
+      env:
+        BASE_COMMIT: ${{ github.sha }}
+        TARGET_BRANCH: ${{ github.event_name == 'release' && 'refs/heads/master' || github.ref }}
+      run: |
+        git push origin \
+          --force-with-lease="$TARGET_BRANCH:$BASE_COMMIT" \
+          "HEAD:$TARGET_BRANCH"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,3 +175,5 @@ tasks {
     }
 
 }
+
+apply(from = "gradle/bumpVersion.gradle.kts")

--- a/gradle/bumpVersion.gradle.kts
+++ b/gradle/bumpVersion.gradle.kts
@@ -1,0 +1,64 @@
+import java.util.regex.Pattern
+
+val GRADLE_PROPERTIES = "gradle.properties"
+val VERSION_PROPERTY = "pluginVersion"
+
+task("bumpVersion") {
+    description = "Bumps the version of the project"
+    dependsOn("patchChangelog")
+    outputs.upToDateWhen { false }
+
+    doLast {
+        val prevVersion = project.property(VERSION_PROPERTY) as String
+        val nextVersion = incrementVersion(prevVersion)
+        replaceInProperties(prevVersion, nextVersion)
+    }
+}
+
+tasks.named("patchChangelog") {
+    // GitHub seems to use CRLF as line feeds.
+    // We have to replace them to avoid files with mixed line endings.
+    doFirst {
+        val releaseNote = property("releaseNote") as String
+        if (releaseNote != null) {
+            setProperty("releaseNote", releaseNote.replace("\r\n", "\n"))
+        }
+    }
+    // The task (as of org.jetbrains.changelog 1.3.1) removes trailing newlines from the changelog.
+    // Add a trailing newline afterwards as a workaround.
+    doLast {
+        val file = file(property("outputFile"))
+        if (!file.readText().endsWith("\n")) {
+            file.appendText("\n")
+        }
+    }
+}
+
+/**
+ * Replaces the [prevVersion] with [nextVersion] for the `pluginVersion` property in `gradle.properties`.
+ */
+fun replaceInProperties(prevVersion: String, nextVersion: String): Unit {
+    val pProperty = Regex.escape(VERSION_PROPERTY)
+    val pVersion = Regex.escape(prevVersion)
+    val rVersion = Regex.escapeReplacement(nextVersion)
+
+    val file = file(GRADLE_PROPERTIES)
+    val previousContent = file.readText()
+    file.writeText(previousContent.replace(
+            Regex("^(\\s*$pProperty\\s*=\\s*)$pVersion(\\s*)$", RegexOption.MULTILINE),
+            "$1${rVersion}$2"))
+}
+
+/**
+ * Increments the last integer within the given string.
+ */
+fun incrementVersion(previous: String): String {
+    val matcher = Pattern.compile("(.*[^\\d])(\\d+)([^\\d]*)").matcher(previous)
+    if (matcher.matches()) {
+        val incrementedNumber = Integer.parseInt(matcher.group(2)) + 1
+        return matcher.group(1) + incrementedNumber + matcher.group(3)
+    }
+    else {
+        throw GradleException("Unsupported version: " + previous)
+    }
+}


### PR DESCRIPTION
Add workflow which bumps the version number after every release.

* The workflow directly pushes onto the master.
* Final adjustments to the release notes in the UI of GitHub are reflected in the `CHANGELOG.md`.
* If the master branch gets updated after a release before this workflow finishes, the workflow will fail.