### PR TITLE
Update to the latest gradle-intellij Gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     // Java support
     id("java")
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.9.0"
+    id("org.jetbrains.intellij") version "1.13.3"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // grammarkit - read more: https://github.com/JetBrains/gradle-grammar-kit-plugin


### PR DESCRIPTION
Updates to the latest version of the Gradle plugin gradle-intellij.
This is a recommendation by JetBrains, but it's also fixing task `buildSearchableOptions`, which was broken with my setup.

My work is a courtesy of https://github.com/monogon-dev.