### PR TITLE
Fix state handling of the lexer

### DIFF
--- a/src/main/java/org/nixos/idea/lang/NixLexer.java
+++ b/src/main/java/org/nixos/idea/lang/NixLexer.java
@@ -1,51 +1,17 @@
 package org.nixos.idea.lang;
 
 import com.intellij.lexer.FlexAdapter;
-import com.intellij.lexer.FlexLexer;
-import com.intellij.psi.tree.IElementType;
-
-import java.io.IOException;
 
 public class NixLexer extends FlexAdapter {
     // todo: Implement RestartableLexer when it becomes non-experimental. See
     //  https://intellij-support.jetbrains.com/hc/en-us/community/posts/360010305800/comments/360002861979
 
     public NixLexer() {
-        // We need this anonymous wrapper class to map between internal states
-        // of Flex and external states for IntelliJ. See
-        // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360010305800
-        super(new FlexLexer() {
-            private final _NixLexer lexer = new _NixLexer(null);
-
+        super(new _NixLexer(null) {
             @Override
-            public void yybegin(int state) {
-                lexer.restoreState(state);
-            }
-
-            @Override
-            public int yystate() {
-                return lexer.getStateIndex();
-            }
-
-            @Override
-            public int getTokenStart() {
-                return lexer.getTokenStart();
-            }
-
-            @Override
-            public int getTokenEnd() {
-                return lexer.getTokenEnd();
-            }
-
-            @Override
-            public IElementType advance() throws IOException {
-                return lexer.advance();
-            }
-
-            @Override
-            public void reset(CharSequence buf, int start, int end, int initialState) {
-                lexer.reset(buf, start, end, _NixLexer.YYINITIAL);
-                lexer.restoreState(initialState);
+            public void reset(CharSequence buffer, int start, int end, int initialState) {
+                onReset();
+                super.reset(buffer, start, end, initialState);
             }
         });
     }

--- a/src/main/lang/Nix.flex
+++ b/src/main/lang/Nix.flex
@@ -2,53 +2,33 @@ package org.nixos.idea.lang;
 
 import com.intellij.lexer.FlexLexer;
 import com.intellij.psi.tree.IElementType;
-import it.unimi.dsi.fastutil.longs.Long2IntMap;
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
-import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.ints.AbstractIntList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import static org.nixos.idea.psi.NixTypes.*;
 
 %%
 
 %{
-  private final LongList states = new LongArrayList();
-  private final Long2IntMap stateIndexMap = new Long2IntOpenHashMap();
+  private final AbstractIntList states = new IntArrayList();
 
-  {
-    states.add(YYINITIAL);
-    stateIndexMap.put(YYINITIAL, 0);
+  private void pushState(int newState) {
+      // store current state on the stack to allow restoring it in popState(...)
+      states.push(yystate());
+      yybegin(newState);
   }
 
-  private int currentStateIndex = 0;
-  private int parentStateIndex = 0;
-
-  public int getStateIndex() {
-    return currentStateIndex;
-  }
-
-  public void restoreState(int stateIndex) {
-    long state = states.getLong(stateIndex);
-    currentStateIndex = stateIndex;
-    parentStateIndex = (int) (state >> 32);
-    yybegin((int) state);
-  }
-
-  private void pushState(int yystate) {
-    long state = ((long) currentStateIndex << 32) | ((long) yystate & 0x0FFFFFFFFL);
-    int stateIndex = stateIndexMap.get(state); // Returns 0 if not found
-    if (stateIndex == 0 && state != YYINITIAL) {
-      stateIndex = states.size();
-      states.add(state);
-      stateIndexMap.put(state, stateIndex);
+  private void popState(int expectedState) {
+    // safe-guard, because we always know which state we're currently in in the rules below
+    if (yystate() != expectedState) {
+        throw new IllegalStateException(String.format("Unexpected state. Current: %d, expected: %d", yystate(), expectedState));
     }
-    parentStateIndex = currentStateIndex;
-    currentStateIndex = stateIndex;
-    yybegin(yystate);
+    // start the lexer with the previous state, which was stored by pushState(...)
+    yybegin(states.popInt());
   }
 
-  private void popState() {
-    restoreState(parentStateIndex);
+  protected void onReset() {
+      states.clear();
   }
 %}
 
@@ -57,7 +37,7 @@ import static org.nixos.idea.psi.NixTypes.*;
 %function advance
 %type IElementType
 %unicode
-%xstate STRING IND_STRING ANTIQUOTATION_START
+%state BLOCK STRING IND_STRING ANTIQUOTATION_START ANTIQUOTATION
 
 ANY=[^]
 ID=[a-zA-Z_][a-zA-Z0-9_'-]*
@@ -74,7 +54,34 @@ MCOMMENT=\/\*([^*]|\*[^\/])*\*\/
 
 %%
 
-<YYINITIAL> {
+<STRING> {
+  [^\$\"\\]+            { return STR; }
+  "$"|"$$"|\\           { return STR; }
+  \\{ANY}               { return STR_ESCAPE; }
+  "$"/"{"               { pushState(ANTIQUOTATION_START); return DOLLAR; }
+  \"                    { popState(STRING); return STRING_CLOSE; }
+}
+
+<IND_STRING> {
+  [^\$\']+              { return IND_STR; }
+  "$"|"$$"|"'"          { return IND_STR; }
+  "''$"|"'''"           { return IND_STR_ESCAPE; }
+  "''"\\{ANY}           { return IND_STR_ESCAPE; }
+  "$"/"{"               { pushState(ANTIQUOTATION_START); return DOLLAR; }
+  "''"                  { popState(IND_STRING); return IND_STRING_CLOSE; }
+}
+
+<ANTIQUOTATION_START> {
+  // '$' and '{' must be two separate tokens to make NixBraceMatcher work
+  // correctly with Grammar-Kit.
+  "{"                   { popState(ANTIQUOTATION_START); pushState(ANTIQUOTATION); return LCURLY; }
+}
+
+<ANTIQUOTATION> {
+  "}"                   { popState(ANTIQUOTATION); return RCURLY; }
+}
+
+<YYINITIAL, BLOCK, ANTIQUOTATION> {
   "if"                  { return IF; }
   "then"                { return THEN; }
   "else"                { return ELSE; }
@@ -94,8 +101,8 @@ MCOMMENT=\/\*([^*]|\*[^\/])*\*\/
   "@"                   { return AT; }
   "("                   { return LPAREN; }
   ")"                   { return RPAREN; }
-  "{"                   { pushState(YYINITIAL); return LCURLY; }
-  "}"                   { popState(); return RCURLY; }
+  "{"                   { pushState(BLOCK); return LCURLY; }
+  "}"                   { popState(BLOCK); return RCURLY; }
   "["                   { return LBRAC; }
   "]"                   { return RBRAC; }
   // '$' and '{' must be two separate tokens to make NixBraceMatcher work
@@ -136,29 +143,8 @@ MCOMMENT=\/\*([^*]|\*[^\/])*\*\/
 
   {SCOMMENT}            { return SCOMMENT; }
   {MCOMMENT}            { return MCOMMENT; }
-  {WHITE_SPACE}         { return com.intellij.psi.TokenType.WHITE_SPACE; }
-  [^]                   { return com.intellij.psi.TokenType.BAD_CHARACTER; }
 }
 
-<STRING> {
-  [^\$\"\\]+            { return STR; }
-  "$"|"$$"|\\           { return STR; }
-  \\{ANY}               { return STR_ESCAPE; }
-  "$"/"{"               { pushState(ANTIQUOTATION_START); return DOLLAR; }
-  \"                    { popState(); return STRING_CLOSE; }
-}
-
-<IND_STRING> {
-  [^\$\']+              { return IND_STR; }
-  "$"|"$$"|"'"          { return IND_STR; }
-  "''$"|"'''"           { return IND_STR_ESCAPE; }
-  "''"\\{ANY}           { return IND_STR_ESCAPE; }
-  "$"/"{"               { pushState(ANTIQUOTATION_START); return DOLLAR; }
-  "''"                  { popState(); return IND_STRING_CLOSE; }
-}
-
-<ANTIQUOTATION_START> {
-  // '$' and '{' must be two separate tokens to make NixBraceMatcher work
-  // correctly with Grammar-Kit.
-  "{"                   { popState(); pushState(YYINITIAL); return LCURLY; }
-}
+// matched by all %state states
+{WHITE_SPACE}           { return com.intellij.psi.TokenType.WHITE_SPACE; }
+[^]                     { return com.intellij.psi.TokenType.BAD_CHARACTER; }

--- a/src/main/lang/Nix.flex
+++ b/src/main/lang/Nix.flex
@@ -13,6 +13,9 @@ import static org.nixos.idea.psi.NixTypes.*;
   private final AbstractIntList states = new IntArrayList();
 
   private void pushState(int newState) {
+      if (newState == YYINITIAL){
+          throw new IllegalStateException("Pusing YYINITIAL is not supported");
+      }
       // store current state on the stack to allow restoring it in popState(...)
       states.push(yystate());
       yybegin(newState);

--- a/src/main/lang/Nix.flex
+++ b/src/main/lang/Nix.flex
@@ -84,6 +84,10 @@ MCOMMENT=\/\*([^*]|\*[^\/])*\*\/
   "}"                   { popState(ANTIQUOTATION); return RCURLY; }
 }
 
+<BLOCK> {
+  "}"                   { popState(BLOCK); return RCURLY; }
+}
+
 <YYINITIAL, BLOCK, ANTIQUOTATION> {
   "if"                  { return IF; }
   "then"                { return THEN; }
@@ -105,7 +109,7 @@ MCOMMENT=\/\*([^*]|\*[^\/])*\*\/
   "("                   { return LPAREN; }
   ")"                   { return RPAREN; }
   "{"                   { pushState(BLOCK); return LCURLY; }
-  "}"                   { popState(BLOCK); return RCURLY; }
+  "}"                   { return RCURLY; }
   "["                   { return LBRAC; }
   "]"                   { return RBRAC; }
   // '$' and '{' must be two separate tokens to make NixBraceMatcher work

--- a/src/main/lang/Nix.flex
+++ b/src/main/lang/Nix.flex
@@ -150,8 +150,8 @@ MCOMMENT=\/\*([^*]|\*[^\/])*\*\/
 
   {SCOMMENT}            { return SCOMMENT; }
   {MCOMMENT}            { return MCOMMENT; }
+  {WHITE_SPACE}         { return com.intellij.psi.TokenType.WHITE_SPACE; }
 }
 
 // matched by all %state states
-{WHITE_SPACE}           { return com.intellij.psi.TokenType.WHITE_SPACE; }
 [^]                     { return com.intellij.psi.TokenType.BAD_CHARACTER; }

--- a/src/main/lang/Nix.flex
+++ b/src/main/lang/Nix.flex
@@ -22,6 +22,9 @@ import static org.nixos.idea.psi.NixTypes.*;
   }
 
   private void popState(int expectedState) {
+    if (states.isEmpty()){
+      throw new IllegalStateException("Popping an empty stack of states. Expected: " + expectedState);
+    }
     // safe-guard, because we always know which state we're currently in in the rules below
     if (yystate() != expectedState) {
         throw new IllegalStateException(String.format("Unexpected state. Current: %d, expected: %d", yystate(), expectedState));

--- a/src/test/java/org/nixos/idea/lang/LexerTest.java
+++ b/src/test/java/org/nixos/idea/lang/LexerTest.java
@@ -7,7 +7,7 @@ public final class LexerTest extends LexerTestCase {
   public void testRestartabilityWithAntiquotations() {
     // Checks that the lexer is restartable. See
     // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360010305800
-    checkCorrectRestartOnEveryToken(
+    checkCorrectRestart(
         "''\n" +
         "  ${\n" +
         "    [\n" +


### PR DESCRIPTION
Previously, the state of the lexer was stored in a stack of longs and a map, which keeps a mapping of index to internal lexer state. The long was composed of the index and the lexer's `yystate()`.
Instead, it's easier to just store `yystate()` in a stack of ints along with a mathing `pushState()` and `popState()`. This is the approach of JetBrain's shell plugin (and a few of my own language plugins )

This changes the parser to not be restartable from any position.
As far as I understand the language and the previous implementation, the inner `FlexLexer.reset(...) in `NixLexer` relies on internal state of `_NixLexer` (i.e. `states` via `_NixLexer.restoreState(...)`).
AFAIK `reset()` shouldn't rely on existing state, but should only rely on the new state.

For example, consider this example with the previous implementation:
```
[
"a ${ "b ${"c"} d" } e"
]
```
After `${` the state is `YYINITIAL` and there would be multiple levels of `YYINITIAL` (because of the nested `${...}`). The most inner push of `YYINITIAL` overrides the state index of the previous `${...}`.
As far as I understand, `d` or at least `e` would not be `STR` tokens because the lexer was restarted with `YYINITIAL` from `c`.

I understand why the lexer was restartable from any position. But in my experience it's better to play safe with the lexer. If performance becomes a problem, it would be possible to implement`LazyParseablePsiElement` instead for block elements `{...}` and antiquotations.

Reasoning about the lexer is definitely difficult and I got confused a few times thinking about it, but I'm hopefully on the right track here.

This is based on https://github.com/NixOS/nix-idea/pull/55 and https://github.com/NixOS/nix-idea/pull/56 to have reliable test data before making the changes of this PR.