### PR TITLE
Fix outdated “What’s New” section

### DIFF
--- a/.github/scripts/get-release-notes.js
+++ b/.github/scripts/get-release-notes.js
@@ -1,0 +1,43 @@
+"use strict";
+
+module.exports = async ({github, context, core, outputFile, releaseTagInput, allowFallbackToLatest}) => {
+  const { RELEASE_TAG_INPUT, ALLOW_FALLBACK_TO_LATEST } = process.env;
+  const fs = require('fs');
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+
+  if (!outputFile) {
+    throw new Error("outputFile not specified");
+  }
+
+  let releaseNote;
+  if (context.eventName === 'release') {
+    releaseNote = context.payload.release.body;
+  }
+  else if (releaseTagInput && context.payload.inputs[releaseTagInput]) {
+    const tag = context.payload.inputs[releaseTagInput];
+    try {
+      const response = await github.rest.repos.getReleaseByTag({owner, repo, tag});
+      releaseNote = response.data.body;
+    }
+    catch (e) {
+      if (e.status === 404) {
+        core.setFailed(`No release with tag '${tag}' has been found.`);
+        return;
+      }
+      else {
+        throw e;
+      }
+    }
+  }
+  else if (allowFallbackToLatest) {
+    const response = await github.rest.repos.getLatestRelease({owner, repo});
+    releaseNote = response.data.body;
+  }
+  else {
+    throw new Error("No release tag specified and allowFallbackToLatest not set");
+  }
+
+  core.info(`Release notes:\n${releaseNote}`);
+  fs.writeFileSync(outputFile, releaseNote, { encoding: 'utf8', flag: 'wx' });
+}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -56,37 +56,12 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          const fs = require('fs');
-          const owner = context.repo.owner;
-          const repo = context.repo.repo;
-          let releaseNote;
-
-          if (context.eventName === 'release') {
-            releaseNote = context.payload.release.body;
-          }
-          else if (context.payload.inputs.release_tag) {
-            const tag = context.payload.inputs.release_tag;
-            try {
-              const response = await github.rest.repos.getReleaseByTag({owner, repo, tag});
-              releaseNote = response.data.body;
-            }
-            catch (e) {
-              if (e.status === 404) {
-                core.setFailed(`No release with tag '${tag}' has been found.`);
-                return;
-              }
-              else {
-                throw e;
-              }
-            }
-          }
-          else {
-            const response = await github.rest.repos.getLatestRelease({owner, repo});
-            releaseNote = response.data.body;
-          }
-
-          core.info(`Release notes:\n${releaseNote}`);
-          fs.writeFileSync('release_note.md', releaseNote, { encoding: 'utf8', flag: 'wx' });
+          await require('.github/scripts/get-release-notes.js')({
+            github, context, core,
+            outputFile: 'release_note.md',
+            releaseTagInput: 'release_tag',
+            allowFallbackToLatest: true,
+          });
     - name: Update files with Gradle
       run: ./gradlew --stacktrace metadata patchChangelog --release-note="$(<release_note.md)" bumpVersion
     # Commit and push

--- a/.github/workflows/publish-to-jetbrains.yml
+++ b/.github/workflows/publish-to-jetbrains.yml
@@ -4,7 +4,11 @@ on:
   release:
     types: [ published ]
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      release_tag:
+        description: 'Use release notes of'
+        type: string
+        required: true
 
 jobs:
   publish:
@@ -33,6 +37,18 @@ jobs:
           ${{hashFiles('gradle/wrapper/gradle-wrapper.properties')}}-\
           ${{hashFiles('gradle.properties', '**/*.gradle.kts')}}"
     # Build and publish
+    - name: Obtain release notes
+      uses: actions/github-script@v6
+      with:
+        script: |
+          await require('.github/scripts/get-release-notes.js')({
+            github, context, core,
+            outputFile: 'release_note.md',
+            releaseTagInput: 'release_tag',
+            allowFallbackToLatest: true,
+          });
+    - name: Patch changelog for release
+      run: ./gradlew --stacktrace patchChangelog --release-note="$(<release_note.md)"
     - name: Build and publish plugin
       id: gradle-build
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+
 ### Added
 
 ### Changed
@@ -14,16 +15,19 @@
 ### Security
 
 ## [0.4.0.9]
+
 ### Added
 - Support for [string interpolation in paths](https://nixos.org/manual/nix/stable/language/string-interpolation#path) (#60)
 
 ## [0.4.0.8]
+
 ### Added
 - Highlighting of built-in functions and constants
 - Support for [semantic highlighting](https://www.jetbrains.com/help/idea/configuring-colors-and-fonts.html#semantic-highlighting)
 - Settings to change the colors used by the highlighter
 
 ## [0.4.0.7]
+
 ### Added
 - Support for IDEA 2023.1 EAP
 
@@ -31,6 +35,7 @@
 - Support for IDEA 2021.3
 
 ## [0.4.0.6]
+
 ### Added
 - Support for IDEA 2022.3 EAP
 
@@ -38,10 +43,12 @@
 - Support for IDEA 2021.2
 
 ## [0.4.0.5]
+
 ### Fixed
 - Trailing commas reported as syntax error (#46)
 
 ## [0.4.0.4]
+
 ### Added
 - Support for IDEA 2022.2 EAP
 
@@ -49,10 +56,12 @@
 - Support for IDEA 2021.1
 
 ## [0.4.0.3]
+
 ### Added
 - Support for IDEA 2022.1
 
 ## [0.4.0.2]
+
 ### Added
 - Support for IDEA 2021.3
 
@@ -60,6 +69,7 @@
 - Support for IDEA 2020.3
 
 ## [0.4.0.1]
+
 ### Added
 - Support for IDEA 2021.2
 
@@ -67,9 +77,9 @@
 - Support for IDEA 2020.2
 
 ## [0.4.0.0]
-
 This release features a complete rewrite of the parser and lexer within
 the plugin.
+
 ### Added
 - Support for the full syntax of Nix 2.3
 
@@ -97,6 +107,7 @@ the plugin.
 - Incorrect reset of parser state when modifying a file
 
 ## [0.3.0.6]
+
 ### Added
 - Support for IDEA 2021.1
 
@@ -104,10 +115,12 @@ the plugin.
 - Support for IDEA 2020.1
 
 ## [0.3.0.5]
+
 ### Added
 - Support line comment and block comment IDEA actions
 
 ## [0.3.0.4]
+
 ### Added
 - Support for IDEA 2020.3
 
@@ -115,6 +128,7 @@ the plugin.
 - Support for IDEA 2019.3
 
 ## [0.3.0.3]
+
 ### Fixed
 - Change ID of plugin back from `org.nixos.idea` in version 0.3.0.0 to
   `nix-idea` from earlier versions. The different ID of version 0.3.0.0
@@ -124,5 +138,23 @@ the plugin.
   file, you should uninstall it when updating to a new version.**
 
 ## [0.3.0.0]
+
 ### Changed
 - Update project to build for recent IJ versions
+
+[Unreleased]: https://github.com/NixOS/nix-idea/compare/v0.4.0.9...HEAD
+[0.3.0.0]: https://github.com/NixOS/nix-idea/commits/v0.3.0.0
+[0.3.0.3]: https://github.com/NixOS/nix-idea/compare/v0.3.0.0...v0.3.0.3
+[0.3.0.4]: https://github.com/NixOS/nix-idea/compare/v0.3.0.3...v0.3.0.4
+[0.3.0.5]: https://github.com/NixOS/nix-idea/compare/v0.3.0.4...v0.3.0.5
+[0.3.0.6]: https://github.com/NixOS/nix-idea/compare/v0.3.0.5...v0.3.0.6
+[0.4.0.0]: https://github.com/NixOS/nix-idea/compare/v0.3.0.6...v0.4.0.0
+[0.4.0.1]: https://github.com/NixOS/nix-idea/compare/v0.4.0.0...v0.4.0.1
+[0.4.0.2]: https://github.com/NixOS/nix-idea/compare/v0.4.0.1...v0.4.0.2
+[0.4.0.3]: https://github.com/NixOS/nix-idea/compare/v0.4.0.2...v0.4.0.3
+[0.4.0.4]: https://github.com/NixOS/nix-idea/compare/v0.4.0.3...v0.4.0.4
+[0.4.0.5]: https://github.com/NixOS/nix-idea/compare/v0.4.0.4...v0.4.0.5
+[0.4.0.6]: https://github.com/NixOS/nix-idea/compare/v0.4.0.5...v0.4.0.6
+[0.4.0.7]: https://github.com/NixOS/nix-idea/compare/v0.4.0.6...v0.4.0.7
+[0.4.0.8]: https://github.com/NixOS/nix-idea/compare/v0.4.0.7...v0.4.0.8
+[0.4.0.9]: https://github.com/NixOS/nix-idea/compare/v0.4.0.8...v0.4.0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Removed
 
 ### Fixed
+- Final changes on release notes not applied to *“What’s New”* section
+  of published plugin
 
 ### Security
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "1.13.3"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "2.0.0"
+    id("org.jetbrains.changelog") version "2.1.0"
     // grammarkit - read more: https://github.com/JetBrains/gradle-grammar-kit-plugin
     id("org.jetbrains.grammarkit") version "2021.2.2"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
@@ -8,7 +9,7 @@ plugins {
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "1.13.3"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "1.3.1"
+    id("org.jetbrains.changelog") version "2.0.0"
     // grammarkit - read more: https://github.com/JetBrains/gradle-grammar-kit-plugin
     id("org.jetbrains.grammarkit") version "2021.2.2"
 }
@@ -52,7 +53,10 @@ intellij {
 }
 
 changelog {
+    lineSeparator.set("\n")
+    // Workarounds because our version numbers do not match the format of semantic versioning:
     headerParserRegex.set("^[-._+0-9a-zA-Z]+\$")
+    combinePreReleases.set(false)
 }
 
 grammarKit {
@@ -129,7 +133,14 @@ tasks {
             dir.mkdirs()
             dir.resolve("version.txt").writeText(pluginVersion)
             dir.resolve("zipfile.txt").writeText(buildPlugin.get().archiveFile.get().toString())
-            dir.resolve("latest_changelog.md").writeText(changelog.getLatest().toText())
+            dir.resolve("latest_changelog.md").writeText(with(changelog) {
+                renderItem(
+                    (getOrNull(pluginVersion) ?: getUnreleased())
+                        .withHeader(false)
+                        .withEmptySections(false),
+                    Changelog.OutputType.MARKDOWN
+                )
+            })
         }
     }
 
@@ -175,7 +186,14 @@ tasks {
         )
 
         // Get the latest available change notes from the changelog file
-        changeNotes.set(provider { changelog.getLatest().toHTML() })
+        changeNotes.set(provider { with(changelog) {
+            renderItem(
+                (getOrNull(pluginVersion) ?: getUnreleased())
+                    .withHeader(false)
+                    .withEmptySections(false),
+                Changelog.OutputType.HTML
+            )
+        }})
     }
 
     runPluginVerifier {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ intellij {
 }
 
 changelog {
+    repositoryUrl.set("https://github.com/NixOS/nix-idea")
     lineSeparator.set("\n")
     // Workarounds because our version numbers do not match the format of semantic versioning:
     headerParserRegex.set("^[-._+0-9a-zA-Z]+\$")

--- a/gradle/bumpVersion.gradle.kts
+++ b/gradle/bumpVersion.gradle.kts
@@ -24,14 +24,6 @@ tasks.named("patchChangelog") {
             setProperty("releaseNote", releaseNote.replace("\r\n", "\n"))
         }
     }
-    // The task (as of org.jetbrains.changelog 1.3.1) removes trailing newlines from the changelog.
-    // Add a trailing newline afterwards as a workaround.
-    doLast {
-        val file = file(property("outputFile"))
-        if (!file.readText().endsWith("\n")) {
-            file.appendText("\n")
-        }
-    }
 }
 
 /**


### PR DESCRIPTION
I noticed that when I change the release notes before creating a release, the changes are written to the `CHANGELOG.md`, but not reflected by the *“What’s New”* section which gets published with the Plugin.

This PR fixes this issue. I also updated the changelog-plugin to the next major version, since I had to re-test the workflows anyway.
Release notes: https://github.com/JetBrains/gradle-changelog-plugin/releases/tag/v2.0.0