### PR TITLE
Some Tools and Fundamentals

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ repositories {
 dependencies {
     testImplementation(platform(libs.junit5.bom))
     testImplementation(libs.junit5.jupiter)
+    testImplementation(libs.junit5.platform.testkit)
     testRuntimeOnly(libs.junit5.vintage.engine)
 }
 
@@ -123,7 +124,9 @@ tasks {
     }
 
     test {
-        useJUnitPlatform()
+        useJUnitPlatform {
+            excludeTags("mock")
+        }
     }
 
     patchPluginXml {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 [libraries]
 junit5-bom = { module = "org.junit:junit-bom", version = "5.9.1" }
 junit5-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit5-platform-testkit = { module = "org.junit.platform:junit-platform-testkit" }
 junit5-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 
 [plugins]

--- a/src/main/java/org/nixos/idea/psi/NixElementFactory.java
+++ b/src/main/java/org/nixos/idea/psi/NixElementFactory.java
@@ -1,0 +1,95 @@
+package org.nixos.idea.psi;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFileFactory;
+import com.intellij.psi.TokenType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.nixos.idea.file.NixFile;
+import org.nixos.idea.file.NixFileType;
+
+import java.util.Objects;
+
+public final class NixElementFactory {
+
+    private NixElementFactory() {} // Cannot be instantiated
+
+    public static @NotNull NixString createString(@NotNull Project project, @NotNull String code) {
+        return createElement(project, NixString.class, "", code, "");
+    }
+
+    public static @NotNull NixAttr createAttr(@NotNull Project project, @NotNull String code) {
+        return createElement(project, NixAttr.class, "x.", code, "");
+    }
+
+    public static @NotNull NixAttrPath createAttrPath(@NotNull Project project, @NotNull String code) {
+        return createElement(project, NixAttrPath.class, "x.", code, "");
+    }
+
+    public static @NotNull NixBind createBind(@NotNull Project project, @NotNull String code) {
+        return createElement(project, NixBind.class, "{", code, "}");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends NixExpr> @NotNull T createExpr(@NotNull Project project, @NotNull String code) {
+        return (T) createElement(project, NixExpr.class, "", code, "");
+    }
+
+    public static <T extends NixPsiElement> @NotNull T createElement(
+            @NotNull Project project, @NotNull Class<T> type,
+            @NotNull String prefix, @NotNull String text, @NotNull String suffix) {
+        return Objects.requireNonNull(
+                createElementOrNull(project, type, prefix, text, suffix),
+                "Invalid " + type.getSimpleName() + ": " + text);
+    }
+
+    private static <T extends NixPsiElement> @Nullable T createElementOrNull(
+            @NotNull Project project, @NotNull Class<T> type,
+            @NotNull String prefix, @NotNull String text, @NotNull String suffix) {
+        NixFile file = createFile(project, prefix + text + suffix);
+        ASTNode current = file.getNode().getFirstChildNode();
+        int offset = 0;
+        while (current != null && offset <= prefix.length()) {
+            int length = current.getTextLength();
+            // Check if we have found the right element
+            if (offset == prefix.length() && length == text.length()) {
+                PsiElement psi = current.getPsi();
+                if (type.isInstance(psi)) {
+                    return containsErrors(current) ? null : type.cast(psi);
+                }
+            }
+            // Check if we should go into or over this element
+            if (offset + length <= prefix.length()) {
+                offset += length;
+                current = current.getTreeNext();
+            } else {
+                current = current.getFirstChildNode();
+            }
+        }
+        return null;
+    }
+
+    private static boolean containsErrors(ASTNode node) {
+        ASTNode current = node.getFirstChildNode();
+        while (current != null) {
+            if (current.getElementType() == TokenType.ERROR_ELEMENT) {
+                return true;
+            }
+            ASTNode next = current.getFirstChildNode();
+            if (next == null) {
+                next = current.getTreeNext();
+                while (next == null && (current = current.getTreeParent()) != node) {
+                    next = current.getTreeNext();
+                }
+            }
+            current = next;
+        }
+        return false;
+    }
+
+    public static @NotNull NixFile createFile(@NotNull Project project, @NotNull String code) {
+        return (NixFile) PsiFileFactory.getInstance(project).createFileFromText("dummy.nix", NixFileType.INSTANCE, code);
+    }
+}

--- a/src/main/java/org/nixos/idea/psi/NixPsiElement.java
+++ b/src/main/java/org/nixos/idea/psi/NixPsiElement.java
@@ -1,0 +1,8 @@
+package org.nixos.idea.psi;
+
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+public interface NixPsiElement extends PsiElement {
+    <T> T accept(@NotNull NixElementVisitor<T> visitor);
+}

--- a/src/main/java/org/nixos/idea/psi/impl/AbstractNixPsiElement.java
+++ b/src/main/java/org/nixos/idea/psi/impl/AbstractNixPsiElement.java
@@ -1,0 +1,14 @@
+package org.nixos.idea.psi.impl;
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.intellij.lang.ASTNode;
+import org.jetbrains.annotations.NotNull;
+import org.nixos.idea.psi.NixPsiElement;
+
+abstract class AbstractNixPsiElement extends ASTWrapperPsiElement implements NixPsiElement {
+
+    AbstractNixPsiElement(@NotNull ASTNode node) {
+        super(node);
+    }
+
+}

--- a/src/main/java/org/nixos/idea/util/NixStringUtil.java
+++ b/src/main/java/org/nixos/idea/util/NixStringUtil.java
@@ -1,0 +1,131 @@
+package org.nixos.idea.util;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.nixos.idea.psi.NixStringText;
+import org.nixos.idea.psi.NixTypes;
+
+/**
+ * Utilities for strings in the Nix Expression Language.
+ */
+public final class NixStringUtil {
+
+    private NixStringUtil() {} // Cannot be instantiated
+
+    /**
+     * Returns the source code for a string in the Nix Expression Language.
+     * When the returned string is evaluated by a Nix interpreter, the result matches the sting given to this method.
+     * The returned string expression is always a double-quoted string.
+     *
+     * <h4>Example</h4>
+     * <pre>{@code System.out.println(quote("This should be escaped: ${}"));}</pre>
+     * The code above prints the following:
+     * <pre>"This should be escaped: \${}"</pre>
+     *
+     * @param unescaped The raw string which shall be the result when the expression is evaluated.
+     * @return Source code for a Nix expression which evaluates to the given string.
+     */
+    @Contract(pure = true)
+    public static @NotNull String quote(@NotNull CharSequence unescaped) {
+        StringBuilder builder = new StringBuilder();
+        builder.append('"');
+        escape(builder, unescaped);
+        builder.append('"');
+        return builder.toString();
+    }
+
+    /**
+     * Escapes the given string for use in a double-quoted string expression in the Nix Expression Language.
+     * Note that it is not safe to combine the results of two method calls with arbitrary input.
+     * For example, the following code would generate a broken result.
+     * <pre>{@code
+     *     StringBuilder b1 = new StringBuilder(), b2 = new StringBuilder();
+     *     NixStringUtil.escape(b1, "$");
+     *     NixStringUtil.escape(b2, "{''}");
+     *     System.out.println(b1.toString() + b2.toString());
+     * }</pre>
+     * The result would be the following broken Nix code.
+     * <pre>
+     *     "${''}"
+     * </pre>
+     *
+     * @param builder   The target string builder. The result will be appended to the given string builder.
+     * @param unescaped The raw string which shall be escaped.
+     */
+    public static void escape(@NotNull StringBuilder builder, @NotNull CharSequence unescaped) {
+        for (int charIndex = 0; charIndex < unescaped.length(); charIndex++) {
+            char nextChar = unescaped.charAt(charIndex);
+            switch (nextChar) {
+                case '"':
+                case '\\':
+                    builder.append('\\').append(nextChar);
+                    break;
+                case '{':
+                    if (builder.charAt(builder.length() - 1) == '$') {
+                        builder.setCharAt(builder.length() - 1, '\\');
+                        builder.append('$').append('{');
+                    } else {
+                        builder.append('{');
+                    }
+                    break;
+                case '\n':
+                    builder.append('\\').append('n');
+                    break;
+                case '\r':
+                    builder.append('\\').append('r');
+                    break;
+                case '\t':
+                    builder.append('\\').append('t');
+                    break;
+                default:
+                    builder.append(nextChar);
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Returns the content of the given part of a string in the Nix Expression Language.
+     * All escape sequences are resolved.
+     *
+     * @param textNode A part of a string.
+     * @return The resulting string after resolving all escape sequences.
+     */
+    public static @NotNull String parse(@NotNull NixStringText textNode) {
+        StringBuilder builder = new StringBuilder();
+        for (ASTNode child = textNode.getNode().getFirstChildNode(); child != null; child = child.getTreeNext()) {
+            parse(builder, child);
+        }
+        return builder.toString();
+    }
+
+    private static void parse(@NotNull StringBuilder builder, @NotNull ASTNode token) {
+        CharSequence text = token.getChars();
+        IElementType type = token.getElementType();
+        if (type == NixTypes.STR || type == NixTypes.IND_STR) {
+            builder.append(text);
+        } else if (type == NixTypes.STR_ESCAPE) {
+            assert text.length() == 2 && text.charAt(0) == '\\' : text;
+            char c = text.charAt(1);
+            builder.append(unescape(c));
+        } else if (type == NixTypes.IND_STR_ESCAPE) {
+            assert text.length() == 3 && ("''$".contentEquals(text) || "'''".contentEquals(text)) ||
+                    text.length() == 4 && "''\\".contentEquals(text.subSequence(0, 3)) : text;
+            char c = text.charAt(text.length() - 1);
+            builder.append(unescape(c));
+        } else {
+            throw new IllegalStateException("Unexpected token in string: " + token);
+        }
+    }
+
+    private static char unescape(char c) {
+        return switch (c) {
+            case 'n' -> '\n';
+            case 'r' -> '\r';
+            case 't' -> '\t';
+            default -> c;
+        };
+    }
+}

--- a/src/main/lang/Nix.bnf
+++ b/src/main/lang/Nix.bnf
@@ -169,7 +169,8 @@ upper legacy_app_or ::= OR_KW { extends=expr_app }
 expr_simple ::=
     identifier
   | literal
-  | string
+  | std_string
+  | ind_string
   | parens
   | set
   | list
@@ -189,9 +190,9 @@ private set_recover ::= curly_recover !bind
 private list_recover ::= brac_recover !expr_select
 
 ;{ extends(".*_string")="string" }
-string ::= std_string | ind_string
 std_string ::= STRING_OPEN string_part* STRING_CLOSE { pin=1 }
 ind_string ::= IND_STRING_OPEN string_part* IND_STRING_CLOSE { pin=1 }
+fake string ::= string_part* { methods=[ string_parts="string_part" ] }
 ;{ extends("string_text|antiquotation")=string_part }
 string_part ::= string_text | antiquotation { recoverWhile=string_part_recover }
 string_text ::= string_token+

--- a/src/main/lang/Nix.bnf
+++ b/src/main/lang/Nix.bnf
@@ -1,16 +1,22 @@
 {
+  // Parser classes
   parserClass="org.nixos.idea.lang.NixParser"
   parserUtilClass="org.nixos.idea.psi.impl.NixParserUtil"
-  extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
-
+  // PSI element interfaces
   psiClassPrefix="Nix"
-  psiImplClassSuffix="Impl"
   psiPackage="org.nixos.idea.psi"
+  implements="org.nixos.idea.psi.NixPsiElement"
+  // PSI element implementations
+  psiImplClassSuffix="Impl"
   psiImplPackage="org.nixos.idea.psi.impl"
-
+  extends="org.nixos.idea.psi.impl.AbstractNixPsiElement"
+  // Constants (NixTypes)
   elementTypeHolderClass="org.nixos.idea.psi.NixTypes"
   elementTypeClass="org.nixos.idea.psi.NixElementType"
   tokenTypeClass="org.nixos.idea.psi.NixTokenType"
+  // Visitor
+  psiVisitorName="NixElementVisitor"
+  generate=[ visitor-value="T" ]
 
   // do not record error reporting information in recover rules and missing_semi
   consumeTokenMethod(".*_recover|missing_semi")="consumeTokenFast"

--- a/src/test/java/org/nixos/idea/_testutil/EdtExtension.java
+++ b/src/test/java/org/nixos/idea/_testutil/EdtExtension.java
@@ -1,0 +1,95 @@
+package org.nixos.idea._testutil;
+
+import com.intellij.ide.IdeEventQueue;
+import com.intellij.testFramework.EdtTestUtil;
+import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
+import org.opentest4j.TestAbortedException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+final class EdtExtension implements InvocationInterceptor {
+
+    @Override
+    public <T> T interceptTestClassConstructor(Invocation<T> invocation, ReflectiveInvocationContext<Constructor<T>> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        return runAndGet(invocation);
+    }
+
+    @Override
+    public void interceptBeforeAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        runAndWait(invocation);
+    }
+
+    @Override
+    public void interceptBeforeEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        runAndWait(invocation);
+    }
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        runAndWait(invocation);
+    }
+
+    @Override
+    public <T> T interceptTestFactoryMethod(Invocation<T> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        return runAndGet(invocation);
+    }
+
+    @Override
+    public void interceptTestTemplateMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        runAndWait(invocation);
+    }
+
+    @Override
+    public void interceptDynamicTest(Invocation<Void> invocation, DynamicTestInvocationContext invocationContext, ExtensionContext extensionContext) throws Throwable {
+        runAndWait(invocation);
+    }
+
+    @Override
+    public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        runAndWait(invocation);
+    }
+
+    @Override
+    public void interceptAfterAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        runAndWait(invocation);
+    }
+
+    private static <T> T runAndGet(Invocation<T> invocation) throws Throwable {
+        @SuppressWarnings("unchecked")
+        T[] result = (T[]) new Object[1];
+        runAndWait(() -> result[0] = invocation.proceed());
+        return result[0];
+    }
+
+    private static void runAndWait(Invocation<?> invocation) throws Throwable {
+        ThrowableCollector uncaughtExceptions = new ThrowableCollector(TestAbortedException.class::isInstance);
+        try (var ignored = wrap(uncaughtExceptions)) {
+            uncaughtExceptions.execute(() -> EdtTestUtil.runInEdtAndWait(invocation::proceed));
+        }
+    }
+
+    private static AutoCloseable wrap(ThrowableCollector uncaughtExceptions) {
+        Thread edt = EdtTestUtil.runInEdtAndGet(Thread::currentThread);
+        Thread.UncaughtExceptionHandler previousExceptionHandler = edt.getUncaughtExceptionHandler();
+        edt.setUncaughtExceptionHandler((thread, exception) -> uncaughtExceptions.execute(() -> {throw exception;}));
+
+        return () -> {
+            try {
+                // Make sure all deferred tasks have finished
+                boolean incomplete;
+                do {
+                    incomplete = EdtTestUtil.runInEdtAndGet(() -> IdeEventQueue.getInstance().peekEvent() != null);
+                } while (incomplete);
+            } finally {
+                edt.setUncaughtExceptionHandler(previousExceptionHandler);
+            }
+            // Re-throw any exception which might have been thrown by deferred tasks
+            uncaughtExceptions.assertEmpty();
+        };
+    }
+}

--- a/src/test/java/org/nixos/idea/_testutil/EdtExtensionTest.java
+++ b/src/test/java/org/nixos/idea/_testutil/EdtExtensionTest.java
@@ -1,0 +1,121 @@
+package org.nixos.idea._testutil;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.util.ui.EDT;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EventConditions;
+import org.junit.platform.testkit.engine.TestExecutionResultConditions;
+
+import javax.swing.SwingUtilities;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+final class EdtExtensionTest {
+
+    @Test
+    void test_is_executed_in_event_dispatch_thread() throws Throwable {
+        runTestLambda(() -> {
+            assertTrue(SwingUtilities.isEventDispatchThread());
+            assertTrue(EDT.isCurrentThreadEdt());
+        });
+    }
+
+    @Test
+    void fail_if_test_throws_exception() {
+        assertThrows(MyException.class, () -> runTestLambda(() -> {
+            throw new MyException();
+        }));
+    }
+
+    @Test
+    void fail_if_deferred_task_from_swing_throws_exception() {
+        assertThrows(MyException.class, () -> runTestLambda(() -> {
+            SwingUtilities.invokeLater(() -> {
+                throw new MyException();
+            });
+        }));
+    }
+
+    @Test
+    void fail_if_deferred_task_from_application_throws_exception() {
+        assertThrows(MyException.class, () -> runTestLambda(() -> {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                throw new MyException();
+            });
+        }));
+    }
+
+    @Test
+    void fail_if_hyper_deferred_task_throws_exception() {
+        assertThrows(MyException.class, () -> runTestLambda(() -> {
+            SwingUtilities.invokeLater(() -> {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    SwingUtilities.invokeLater(() -> {
+                        ApplicationManager.getApplication().invokeLater(() -> {
+                            throw new MyException();
+                        });
+                    });
+                });
+            });
+        }));
+    }
+
+    @Test
+    void later_exceptions_are_added_as_suppressed_exceptions() {
+        EngineExecutionResults results = ExtensionTestUtil.runTests(testLambda(() -> {
+            SwingUtilities.invokeLater(() -> {
+                SwingUtilities.invokeLater(() -> {
+                    throw new MyException("deferred 2");
+                });
+                throw new MyException("deferred 1");
+            });
+            throw new MyException("first");
+        }));
+        results.testEvents().assertThatEvents().haveExactly(1, EventConditions.finishedWithFailure(
+                TestExecutionResultConditions.instanceOf(MyException.class),
+                TestExecutionResultConditions.message("first"),
+                TestExecutionResultConditions.suppressed(0,
+                        TestExecutionResultConditions.instanceOf(MyException.class),
+                        TestExecutionResultConditions.message("deferred 1")
+                ),
+                TestExecutionResultConditions.suppressed(1,
+                        TestExecutionResultConditions.instanceOf(MyException.class),
+                        TestExecutionResultConditions.message("deferred 2")
+                )
+        ));
+    }
+
+    private static void runTestLambda(EdtMockTest lambda) throws Throwable {
+        ExtensionTestUtil.runTest(testLambda(lambda));
+    }
+
+    private static DiscoverySelector testLambda(EdtMockTest lambda) {
+        return selectClass(lambda.getClass());
+    }
+
+    @FunctionalInterface
+    private interface EdtMockTest {
+
+        void testInternal() throws Throwable;
+
+        @ExtensionTestUtil.MockTest
+        @WithIdeaPlatform.OnEdt
+        @SuppressWarnings("unused")
+        default void test() throws Throwable {
+            testInternal();
+        }
+    }
+
+    private static final class MyException extends RuntimeException {
+
+        public MyException() {}
+
+        private MyException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/test/java/org/nixos/idea/_testutil/ExtensionTestUtil.java
+++ b/src/test/java/org/nixos/idea/_testutil/ExtensionTestUtil.java
@@ -1,0 +1,59 @@
+package org.nixos.idea._testutil;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Execution;
+import org.junit.platform.testkit.engine.TerminationInfo;
+
+import java.lang.annotation.*;
+import java.util.List;
+
+final class ExtensionTestUtil {
+    private static final String TEST_KIT_MARKER = "nix-idea.run-mocks";
+
+    private ExtensionTestUtil() {} // Cannot be instantiated
+
+    static void runTest(DiscoverySelector selector) throws Throwable {
+        List<Execution> executions = runTests(selector).testEvents().executions().list();
+        if (executions.size() != 1) {
+            throw new IllegalStateException("Expected exactly one test execution, got: " + executions);
+        }
+        TerminationInfo terminationInfo = executions.get(0).getTerminationInfo();
+        TestExecutionResult executionResult = terminationInfo.getExecutionResult();
+        if (executionResult.getStatus() != TestExecutionResult.Status.SUCCESSFUL) {
+            throw executionResult.getThrowable().orElseThrow();
+        }
+    }
+
+    static EngineExecutionResults runTests(DiscoverySelector... selectors) {
+        return EngineTestKit.engine("junit-jupiter")
+                .configurationParameter(TEST_KIT_MARKER, "true")
+                .selectors(selectors)
+                .execute();
+    }
+
+    @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @Test
+    @Tag("mock")
+    @ExtendWith(DisableOutsideTestKit.class)
+    @interface MockTest {}
+
+    private static final class DisableOutsideTestKit implements ExecutionCondition {
+        @Override
+        public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+            return context.getConfigurationParameter(TEST_KIT_MARKER).isPresent()
+                    ? ConditionEvaluationResult.enabled("Test executed by ExtensionTestUtil")
+                    : ConditionEvaluationResult.disabled("@MockTest triggered outside ExtensionTestUtil");
+        }
+    }
+}

--- a/src/test/java/org/nixos/idea/_testutil/IdeaPlatformExtension.java
+++ b/src/test/java/org/nixos/idea/_testutil/IdeaPlatformExtension.java
@@ -1,0 +1,98 @@
+package org.nixos.idea._testutil;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.testFramework.PlatformTestUtil;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
+import org.junit.jupiter.api.extension.TestInstancePreConstructCallback;
+import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
+
+import java.util.Map;
+import java.util.function.Function;
+
+final class IdeaPlatformExtension implements ParameterResolver, TestInstancePreConstructCallback, TestInstancePreDestroyCallback {
+    private static final Namespace NAMESPACE = Namespace.create(IdeaPlatformExtension.class);
+    private static final Map<Class<?>, Function<ExtensionContext, ?>> PARAMETER_FACTORIES = Map.ofEntries(
+            createResolver(IdeaProjectTestFixture.class, IdeaPlatformExtension::resolveFixture),
+            createResolver(IdeaTestFixture.class, IdeaPlatformExtension::resolveFixture),
+            createResolver(Project.class, IdeaPlatformExtension::resolveProject),
+            createResolver(Module.class, IdeaPlatformExtension::resolveModule),
+            createResolver(Disposable.class, IdeaPlatformExtension::resolveDisposable)
+    );
+
+    @Override
+    public void preConstructTestInstance(TestInstanceFactoryContext factoryContext, ExtensionContext context) throws Exception {
+        context.getStore(NAMESPACE).put(FixtureClosableWrapper.class, new FixtureClosableWrapper(context));
+    }
+
+    @Override
+    public void preDestroyTestInstance(ExtensionContext context) throws Exception {
+        // Unfortunately, the ExtensionContext given to `preConstructTestInstance` is not scoped to the individual test.
+        // We therefore have cleanup the context manually.
+        // https://github.com/junit-team/junit5/issues/3445
+        FixtureClosableWrapper wrapper;
+        do {
+            wrapper = context.getStore(NAMESPACE).remove(FixtureClosableWrapper.class, FixtureClosableWrapper.class);
+            context = context.getParent().orElse(null);
+        } while (context != null && wrapper == null);
+        if (wrapper != null) wrapper.close();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return PARAMETER_FACTORIES.containsKey(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return PARAMETER_FACTORIES.get(parameterContext.getParameter().getType()).apply(extensionContext);
+    }
+
+    private static IdeaProjectTestFixture resolveFixture(ExtensionContext context) {
+        return context.getStore(NAMESPACE).get(FixtureClosableWrapper.class, FixtureClosableWrapper.class).myFixture;
+    }
+
+    private static Project resolveProject(ExtensionContext context) {
+        return resolveFixture(context).getProject();
+    }
+
+    private static Module resolveModule(ExtensionContext context) {
+        return resolveFixture(context).getModule();
+    }
+
+    private static Disposable resolveDisposable(ExtensionContext context) {
+        return resolveFixture(context).getTestRootDisposable();
+    }
+
+    private static <T> Map.Entry<Class<T>, Function<ExtensionContext, T>> createResolver(Class<T> type, Function<ExtensionContext, T> resolver) {
+        return Map.entry(type, resolver);
+    }
+
+    private static final class FixtureClosableWrapper implements CloseableResource {
+        private final IdeaProjectTestFixture myFixture;
+
+        private FixtureClosableWrapper(ExtensionContext context) throws Exception {
+            String testName = PlatformTestUtil.getTestName(context.getDisplayName(), false);
+            IdeaTestFixtureFactory factory = IdeaTestFixtureFactory.getFixtureFactory();
+            myFixture = factory.createLightFixtureBuilder(testName).getFixture();
+            myFixture.setUp();
+        }
+
+        @Override
+        public void close() throws Exception {
+            // IdeaTestFixture.tearDown() throws an exception when executed outside the event dispatch thread.
+            // Interestingly, IdeaTestFixture.setUp() can also be called outside the event dispatch thread.
+            EdtTestUtil.runInEdtAndWait(myFixture::tearDown);
+        }
+    }
+}

--- a/src/test/java/org/nixos/idea/_testutil/WithIdeaPlatform.java
+++ b/src/test/java/org/nixos/idea/_testutil/WithIdeaPlatform.java
@@ -1,0 +1,59 @@
+package org.nixos.idea._testutil;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.lang.annotation.*;
+
+/**
+ * {@code @WithIdeaPlatform} can be used to set up an IDEA platform test environment.
+ * This extension is an alternative for {@link BasePlatformTestCase}, but for JUnit 5.
+ * The extension is rather simple and does not support all the features of {@code BasePlatformTestCase}.
+ *
+ * <h2>Supported Parameters</h2>
+ * <ul>
+ *     <li>{@link IdeaProjectTestFixture}
+ *     <li>{@link Project} <small>– shortcut for {@link IdeaProjectTestFixture#getProject()}</small>
+ *     <li>{@link Module} <small>– shortcut for {@link IdeaProjectTestFixture#getModule()}</small>
+ *     <li>{@link Disposable} <small>– shortcut for {@link IdeaProjectTestFixture#getTestRootDisposable()}</small>
+ * </ul>
+ *
+ * <h2><a id="edt"></a>Event Dispatch Thread</h2>
+ * As documented at <a href="https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html">
+ * General Threading Rules</a> by JetBrains, many parts of the IDEA platform cannot be accessed from arbitrary threads.
+ * <em>JUnit</em>'s worker thread is not allowed to access these parts of the platform without further effort.
+ * While the worker thread could gain read access to the platform by starting a read action,
+ * write access can only be obtained from the event dispatch thread.
+ * For convenience, you may use {@link OnEdt @WithIdeaPlatform.OnEdt} and
+ * JUnit will call all your test methods on the event dispatch thread.
+ * Otherwise, you may use {@link Application#runReadAction(Runnable)} or {@link ReadAction} for starting a read action,
+ * {@link EdtTestUtil} for running some code on the event dispatch thread, and
+ * {@link Application#runWriteAction(Runnable)} or {@link WriteAction} for starting a write action.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE})
+@Inherited
+@ExtendWith(IdeaPlatformExtension.class)
+@ResourceLock("com.intellij.IdeaPlatform")
+public @interface WithIdeaPlatform {
+    /**
+     * Executes the test method and lifecycle methods on the
+     * <a href="WithIdeaPlatform.html#edt">event dispatch thread</a>.
+     * This annotation inherits {@link WithIdeaPlatform}, so you don't have to add it separately.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE})
+    @Inherited
+    @ExtendWith(EdtExtension.class)
+    @WithIdeaPlatform
+    @interface OnEdt {}
+}

--- a/src/test/java/org/nixos/idea/psi/NixElementFactoryTest.java
+++ b/src/test/java/org/nixos/idea/psi/NixElementFactoryTest.java
@@ -1,0 +1,107 @@
+package org.nixos.idea.psi;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.tree.IElementType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.nixos.idea._testutil.WithIdeaPlatform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@WithIdeaPlatform.OnEdt
+final class NixElementFactoryTest {
+
+    private final Project myProject;
+
+    NixElementFactoryTest(Project project) {
+        myProject = project;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\"\"", "''''", "\"x\"", "''abc''", "\"x${y}z\"", "''${\"42\"}''"})
+    void createString(String code) {
+        NixString result = NixElementFactory.createString(myProject, code);
+        assertEquals(code, result.getText());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "''", "\"", "\"x\" \"y\"", "''abc'' suffix", "${\"x\"}", "''${\"${❌}\"}''"})
+    void createStringFail(String code) {
+        assertThrows(RuntimeException.class,
+                () -> NixElementFactory.createString(myProject, code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"x", "\"x\"", "${x}", "${\"x\"}", "\"x${y}z\""})
+    void createAttr(String code) {
+        NixAttr result = NixElementFactory.createAttr(myProject, code);
+        assertEquals(code, result.getText());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "x.y", "x y"})
+    void createAttrFail(String code) {
+        assertThrows(RuntimeException.class,
+                () -> NixElementFactory.createAttr(myProject, code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"x", "x.y", "x . y", "x.\"y\".${z}"})
+    void createAttrPath(String code) {
+        NixAttrPath result = NixElementFactory.createAttrPath(myProject, code);
+        assertEquals(code, result.getText());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", ".", ".x", "x.", "x y"})
+    void createAttrPathFail(String code) {
+        assertThrows(RuntimeException.class,
+                () -> NixElementFactory.createAttrPath(myProject, code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a = x;", "a.b = x;", "inherit a;", "inherit (x) a;"})
+    void createBind(String code) {
+        NixBind result = NixElementFactory.createBind(myProject, code);
+        assertEquals(code, result.getText());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "a = x"})
+    void createBindFail(String code) {
+        assertThrows(RuntimeException.class,
+                () -> NixElementFactory.createBind(myProject, code));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "IND_STRING, ''abc''",
+            "IDENTIFIER, x",
+            "EXPR_SELECT, x.y",
+            "LIST, []",
+            "LIST, [x y z]",
+            "SET, {}",
+            "SET, {x = y; y = z;}",
+            "EXPR_IF, if x then y else z",
+            "EXPR_LAMBDA, x: x",
+            "EXPR_LET, let x = y; y = z; in x",
+            "LEGACY_LET, let { x = y; body = x; }",
+            "EXPR_OP_PLUS, 2 + 2",
+            "EXPR_WITH, with x; y",
+    })
+    void createExpr(String typeName, String code) throws Exception {
+        NixExpr result = NixElementFactory.createExpr(myProject, code);
+        IElementType type = (IElementType) NixTypes.class.getField(typeName).get(null);
+        assertEquals(code, result.getText());
+        assertEquals(type, result.getNode().getElementType());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "x = y;"})
+    void createExprFail(String code) {
+        assertThrows(RuntimeException.class,
+                () -> NixElementFactory.createExpr(myProject, code));
+    }
+}

--- a/src/test/java/org/nixos/idea/util/NixStringUtilTest.java
+++ b/src/test/java/org/nixos/idea/util/NixStringUtilTest.java
@@ -1,0 +1,94 @@
+package org.nixos.idea.util;
+
+import com.intellij.openapi.project.Project;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.nixos.idea._testutil.WithIdeaPlatform;
+import org.nixos.idea.psi.NixElementFactory;
+import org.nixos.idea.psi.NixString;
+import org.nixos.idea.psi.NixStringPart;
+import org.nixos.idea.psi.NixStringText;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class NixStringUtilTest {
+    @ParameterizedTest(name = "[{index}] {0} -> {1}")
+    @CsvSource(textBlock = """
+            ''              , ""
+            abc             , "abc"
+            "               , "\\\""
+            \\              , "\\\\"
+            \\x             , "\\\\x"
+            a${b}c          , "a\\${b}c"
+            '\n'            , "\\n"
+            '\r'            , "\\r"
+            '\t'            , "\\t"
+            # supplementary character, i.e. character form a supplementary plane,
+            # which needs a surrogate pair to be represented in UTF-16
+            \uD83C\uDF09    , "\uD83C\uDF09"
+            """)
+    void quote(String unescaped, String expectedResult) {
+        assertEquals(expectedResult, NixStringUtil.quote(unescaped));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0} -> {1}")
+    @CsvSource(textBlock = """
+            ''              , ''
+            abc             , abc
+            "               , \\"
+            \\              , \\\\
+            \\x             , \\\\x
+            a${b}c          , a\\${b}c
+            '\n'            , \\n
+            '\r'            , \\r
+            '\t'            , \\t
+            # supplementary character, i.e. character form a supplementary plane,
+            # which needs a surrogate pair to be represented in UTF-16
+            \uD83C\uDF09    , \uD83C\uDF09
+            """)
+    void escape(String unescaped, String expectedResult) {
+        StringBuilder stringBuilder = new StringBuilder();
+        NixStringUtil.escape(stringBuilder, unescaped);
+        assertEquals(expectedResult, stringBuilder.toString());
+    }
+
+    @ParameterizedTest(name = "[{index}] {0} -> {1}")
+    @CsvSource(quoteCharacter = '|', textBlock = """
+            ""              , ||
+            "x"             , x
+            ''abc''         , abc
+            "\\""           , "
+            "\\\\"          , \\
+            "\\\\x"         , \\x
+            ''\\"''         , \\"
+            ''\\\\''        , \\\\
+            ''\\\\x''       , \\\\x
+            ''''\\"''       , "
+            ''''\\\\''      , \\
+            ''''\\\\x''     , \\x
+            "''\\""         , ''"
+            "a\\${b}c"      , a${b}c
+            ''a''${b}c''    , a${b}c
+            ''a''\\${b}c''  , a${b}c
+            "a$${b}c"       , a$${b}c
+            ''a$${b}c''     , a$${b}c
+            |"\n"|          , |\n|
+            |"\r"|          , |\r|
+            |"\t"|          , |\t|
+            # supplementary character, i.e. character form a supplementary plane,
+            # which needs a surrogate pair to be represented in UTF-16
+            "\uD83C\uDF09"  , \uD83C\uDF09
+            ''\uD83C\uDF09'', \uD83C\uDF09
+            """)
+    @WithIdeaPlatform.OnEdt
+    void parse(String code, String expectedResult, Project project) {
+        NixString string = NixElementFactory.createString(project, code);
+        List<NixStringPart> parts = string.getStringParts();
+        assert parts.isEmpty() || parts.size() == 1;
+        for (NixStringPart part : parts) {
+            assertEquals(expectedResult, NixStringUtil.parse((NixStringText) part));
+        }
+    }
+}


### PR DESCRIPTION
This PR extracts a few basics from #63. While the code is currently unused (besides tests), it will be needed sooner or later. The following is added by this PR:

* JUnit 5 extension which allows writing IntelliJ Platform tests with JUnit 5. With JUnit 5, it is much easier to write parameterized tests compared to JUnit 4. Some tests introduced by this PR will already use this extension.
* `NixPsiElement`, a common interface and superclass for all PSI-elements for the Nix Expression Language.
* `NixElementFactory`, to create AST nodes of the Nix Expression Language.
* Parsing and escaping of strings in the Nix Expression Language.