### PR TITLE
Upgrade README to require at least JDK 17  

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ yourself as described below.
 Follow the following steps before you build the project the first time.
 
  *  Clone the repository
- *  Ensure that you have a JDK for Java 11 or higher on your PATH
+ *  Ensure that you have a JDK for Java 17 or higher on your PATH
  *  Only on NixOS: Setup JetBrains Runtime (JBR) from `<nixpkgs>`
     ```sh
     nix-build '<nixpkgs>' -A jetbrains.jdk -o jbr


### PR DESCRIPTION
This change updates the project's requirements to mandate at least JDK 17. The primary reason is compatibility with the `intellij-platform-gradle-plugin` version 2.0.1, which is built for Java 17.  

Attempts to resolve dependencies with Java 11 fail due to compatibility issues, as the plugin's `apiElements` and `runtimeElements` require Java 17. Additionally, Gradle features used by the plugin, such as `org.gradle.plugin.api-version=8.6`, further necessitate upgrading the JDK.