### PR TITLE
add support for path references

### DIFF
--- a/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
+++ b/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
@@ -38,7 +38,7 @@ class NixFilePathReferenceContributor: PsiReferenceContributor() {
 private class NixImportReferenceImpl(key: NixExprPathMixin) : PsiReferenceBase<NixExprPathMixin>(key) {
     override fun resolve(): PsiElement? {
         val path = element.containingFile.parent?.virtualFile?.path ?: return null
-        val resolvedPath = nixEval(path, element.text) ?: return null
+        val resolvedPath = resolvePath(path, element.text) ?: return null
 
         val file = LocalFileSystem.getInstance().findFileByPath(resolvedPath) ?: return null
         val project = element.project
@@ -50,6 +50,15 @@ private class NixImportReferenceImpl(key: NixExprPathMixin) : PsiReferenceBase<N
     override fun getVariants(): Array<out LookupElement> = LookupElement.EMPTY_ARRAY
 
     override fun calculateDefaultRangeInElement(): TextRange = TextRange.from(0, element.textLength)
+}
+
+fun resolvePath(cwd: String, target: String): String? {
+    val path = nixEval(cwd, target) ?: return null
+    if (!path.endsWith(".nix")) {
+        return "$path/default.nix";
+    }
+
+    return path
 }
 
 fun nixEval(path: String, expr: String): String? {

--- a/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
+++ b/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
@@ -1,0 +1,80 @@
+package org.nixos.idea.imports
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiReferenceContributor
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.psi.PsiReferenceRegistrar
+import com.intellij.util.ProcessingContext
+import kotlinx.serialization.json.Json
+import org.nixos.idea.psi.impl.NixExprPathMixin
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+
+class NixFilePathReferenceContributor: PsiReferenceContributor() {
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
+        registrar.registerReferenceProvider(
+            PlatformPatterns.psiElement(NixExprPathMixin::class.java),
+            object : PsiReferenceProvider() {
+                override fun getReferencesByElement(
+                    element: PsiElement,
+                    context: ProcessingContext
+                ): Array<PsiReference> {
+                    val it = element as? NixExprPathMixin ?: return emptyArray()
+                    return arrayOf(NixImportReferenceImpl(it))
+                }
+            }
+        )
+    }
+}
+
+private class NixImportReferenceImpl(key: NixExprPathMixin) : PsiReferenceBase<NixExprPathMixin>(key) {
+    override fun resolve(): PsiElement? {
+        val path = element.containingFile.parent?.virtualFile?.path ?: return null
+        val resolvedPath = nixEval(path, element.text) ?: return null
+
+        val file = LocalFileSystem.getInstance().findFileByPath(resolvedPath) ?: return null
+        val project = element.project
+        val psiFile = PsiManager.getInstance(project).findFile(file)
+
+        return psiFile
+    }
+
+    override fun getVariants(): Array<out LookupElement> = LookupElement.EMPTY_ARRAY
+
+    override fun calculateDefaultRangeInElement(): TextRange = TextRange.from(0, element.textLength)
+}
+
+fun nixEval(path: String, expr: String): String? {
+    val command = listOf("nix", "eval", "--impure", "--expr", expr, "--json")
+
+    try {
+        val process = ProcessBuilder(command)
+            .directory(File(path))
+            .start()
+
+        val stdout = BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
+            reader.readText()
+        }
+
+        val stderr = BufferedReader(InputStreamReader(process.errorStream)).use { reader ->
+            reader.readText()
+        }
+
+        val exitCode = process.waitFor()
+        if (exitCode == 0) {
+            return Json.decodeFromString<String>(stdout)
+        } else {
+            return null
+        }
+    } catch (e: Exception) {
+        return null
+    }
+}

--- a/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
+++ b/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
@@ -15,18 +15,18 @@ import com.intellij.psi.PsiReferenceContributor
 import com.intellij.psi.PsiReferenceProvider
 import com.intellij.psi.PsiReferenceRegistrar
 import com.intellij.util.ProcessingContext
-import org.nixos.idea.psi.impl.NixExprPathMixin
+import org.nixos.idea.psi.impl.NixExprStdPathMixin
 
 class NixFilePathReferenceContributor: PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
         registrar.registerReferenceProvider(
-            PlatformPatterns.psiElement(NixExprPathMixin::class.java),
+            PlatformPatterns.psiElement(NixExprStdPathMixin::class.java),
             object : PsiReferenceProvider() {
                 override fun getReferencesByElement(
                     element: PsiElement,
                     context: ProcessingContext
                 ): Array<PsiReference> {
-                    val it = element as? NixExprPathMixin ?: return emptyArray()
+                    val it = element as? NixExprStdPathMixin ?: return emptyArray()
                     return arrayOf(NixImportReferenceImpl(it))
                 }
             }
@@ -34,7 +34,7 @@ class NixFilePathReferenceContributor: PsiReferenceContributor() {
     }
 }
 
-private class NixImportReferenceImpl(key: NixExprPathMixin) : PsiReferenceBase<NixExprPathMixin>(key) {
+private class NixImportReferenceImpl(key: NixExprStdPathMixin) : PsiReferenceBase<NixExprStdPathMixin>(key) {
     override fun resolve(): PsiElement? {
         val path = element.containingFile.parent?.virtualFile?.path ?: return null
         val fs = LocalFileSystem.getInstance()

--- a/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
+++ b/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt
@@ -51,7 +51,7 @@ private class NixImportReferenceImpl(key: NixExprStdPathMixin) : PsiReferenceBas
     override fun calculateDefaultRangeInElement(): TextRange = TextRange.from(0, element.textLength)
 }
 
-fun resolvePath(fs: VirtualFileSystem, cwd: String, target: String): VirtualFile? {
+private fun resolvePath(fs: VirtualFileSystem, cwd: String, target: String): VirtualFile? {
     val resolved = FileUtil.join(cwd, target)
     val resolvedFile = fs.findFileByPath(resolved) ?: return null
 

--- a/src/main/java/org/nixos/idea/psi/impl/NixExprPathMixin.kt
+++ b/src/main/java/org/nixos/idea/psi/impl/NixExprPathMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiReference
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
 
-open class NixExprPathMixin(node: ASTNode): NixExprSimpleImpl(node) {
+open class NixExprPathMixin(node: ASTNode): NixExprPathImpl(node) {
     override fun getReferences(): Array<PsiReference> =
         ReferenceProvidersRegistry.getReferencesFromProviders(this)
 }

--- a/src/main/java/org/nixos/idea/psi/impl/NixExprPathMixin.kt
+++ b/src/main/java/org/nixos/idea/psi/impl/NixExprPathMixin.kt
@@ -1,0 +1,10 @@
+package org.nixos.idea.psi.impl
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiReference
+import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
+
+open class NixExprPathMixin(node: ASTNode): NixExprSimpleImpl(node) {
+    override fun getReferences(): Array<PsiReference> =
+        ReferenceProvidersRegistry.getReferencesFromProviders(this)
+}

--- a/src/main/java/org/nixos/idea/psi/impl/NixExprStdPathMixin.kt
+++ b/src/main/java/org/nixos/idea/psi/impl/NixExprStdPathMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiReference
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
 
-open class NixExprPathMixin(node: ASTNode): NixExprPathImpl(node) {
+open class NixExprStdPathMixin(node: ASTNode): NixExprPathImpl(node) {
     override fun getReferences(): Array<PsiReference> =
         ReferenceProvidersRegistry.getReferencesFromProviders(this)
 }

--- a/src/main/lang/Nix.bnf
+++ b/src/main/lang/Nix.bnf
@@ -189,11 +189,11 @@ expr_float ::= FLOAT
 expr_string ::= expr_uri | std_string | ind_string
 expr_uri ::= URI
 ;{ extends("expr_lookup_path|expr_std_path")=expr_path }
-expr_path ::= expr_lookup_path | expr_std_path {
+expr_path ::= expr_lookup_path | expr_std_path
+expr_lookup_path ::= SPATH
+expr_std_path ::= PATH_SEGMENT (PATH_SEGMENT | antiquotation)* PATH_END {
   mixin="org.nixos.idea.psi.impl.NixExprPathMixin"
 }
-expr_lookup_path ::= SPATH
-expr_std_path ::= PATH_SEGMENT (PATH_SEGMENT | antiquotation)* PATH_END
 expr_parens ::= LPAREN expr recover_parens RPAREN { pin=1 }
 expr_attrs ::= [ REC | LET ] LCURLY recover_set (bind recover_set)* RCURLY { pin=2 }
 expr_list ::= LBRAC recover_list (expr_select recover_list)* RBRAC { pin=1 }

--- a/src/main/lang/Nix.bnf
+++ b/src/main/lang/Nix.bnf
@@ -189,7 +189,9 @@ expr_float ::= FLOAT
 expr_string ::= expr_uri | std_string | ind_string
 expr_uri ::= URI
 ;{ extends("expr_lookup_path|expr_std_path")=expr_path }
-expr_path ::= expr_lookup_path | expr_std_path
+expr_path ::= expr_lookup_path | expr_std_path {
+  mixin="org.nixos.idea.psi.impl.NixExprPathMixin"
+}
 expr_lookup_path ::= SPATH
 expr_std_path ::= PATH_SEGMENT (PATH_SEGMENT | antiquotation)* PATH_END
 expr_parens ::= LPAREN expr recover_parens RPAREN { pin=1 }

--- a/src/main/lang/Nix.bnf
+++ b/src/main/lang/Nix.bnf
@@ -192,7 +192,7 @@ expr_uri ::= URI
 expr_path ::= expr_lookup_path | expr_std_path
 expr_lookup_path ::= SPATH
 expr_std_path ::= PATH_SEGMENT (PATH_SEGMENT | antiquotation)* PATH_END {
-  mixin="org.nixos.idea.psi.impl.NixExprPathMixin"
+  mixin="org.nixos.idea.psi.impl.NixExprStdPathMixin"
 }
 expr_parens ::= LPAREN expr recover_parens RPAREN { pin=1 }
 expr_attrs ::= [ REC | LET ] LCURLY recover_set (bind recover_set)* RCURLY { pin=2 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <depends optional="true" config-file="nix-idea-ultimate.xml">com.intellij.modules.ultimate</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+
         <fileType
                 name="Nix file"
                 implementationClass="org.nixos.idea.file.NixFileType"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,9 @@
     <depends optional="true" config-file="nix-idea-ultimate.xml">com.intellij.modules.ultimate</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <psi.referenceContributor
+                language="Nix"
+                implementation="org.nixos.idea.imports.NixFilePathReferenceContributor" />
 
         <fileType
                 name="Nix file"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,10 +5,6 @@
     <depends optional="true" config-file="nix-idea-ultimate.xml">com.intellij.modules.ultimate</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <psi.referenceContributor
-                language="Nix"
-                implementation="org.nixos.idea.imports.NixFilePathReferenceContributor" />
-
         <fileType
                 name="Nix file"
                 implementationClass="org.nixos.idea.file.NixFileType"
@@ -40,6 +36,10 @@
 
         <searcher forClass="com.intellij.find.usages.api.UsageSearchParameters"
                   implementationClass="org.nixos.idea.lang.references.NixUsageSearcher"/>
+
+        <psi.referenceContributor
+                language="Nix"
+                implementation="org.nixos.idea.imports.NixFilePathReferenceContributor" />
 
         <projectConfigurable
                 parentId="build"


### PR DESCRIPTION
This PR adds go to declaration for nix path references.

https://github.com/user-attachments/assets/ad9df5d0-c538-4033-b46c-83feb93efea3

I've kept it as simple as possible. It only supports stdpaths and not lookup paths. References are resolved following a simple set of rules.

https://github.com/NixOS/nix-idea/blob/71a79a43dae8ae65cf094df3e3f03a5a6cbb80c9/src/main/java/org/nixos/idea/imports/NixFilePathReferenceContributor.kt#L54-L63

I spend hours a day reading nix files in IJ and this plugin is an important part of making this bearable. Thanks for making this, its really nice.