### PR TITLE
Make nixd's noogle.dev code action workaround also work in case of invalid syntax

### DIFF
--- a/src/main/java/org/nixos/idea/lsp/NixLspServerDescriptor.kt
+++ b/src/main/java/org/nixos/idea/lsp/NixLspServerDescriptor.kt
@@ -33,20 +33,26 @@ internal class NixLspServerDescriptor(project: Project, private var settings: Ni
 
     override val lspCustomization: LspCustomization = object : LspCustomization() {
         override val codeActionsCustomizer = object : LspCodeActionsSupport() {
-            private fun getNoogleUrl(codeAction: CodeAction): String? =
-                (codeAction.data as? JsonObject)?.get("noogleUrl")?.asString
-
-            override fun createIntentionAction(lspServer: LspServer, codeAction: CodeAction): LspIntentionAction? {
-                if (getNoogleUrl(codeAction) != null) {
-                    /* set an empty edit to prevent the IDE from calling
-                       the LSP server and automatically opening the url */
-                    codeAction.edit = WorkspaceEdit()
-                    return object : LspIntentionAction(lspServer, codeAction) {
-                        override fun invoke(project: Project, editor: Editor, psiFile: PsiFile) {
-                            BrowserUtil.open(getNoogleUrl(codeAction)!!)
-                        }
+            private fun handleOpenNoogleCodeAction(lspServer: LspServer, codeAction: CodeAction): LspIntentionAction? {
+                var noogleUrl = (codeAction.data as? JsonObject)?.get("noogleUrl")?.asString ?: return null
+                /* set an empty edit to prevent the IDE from calling
+                   the LSP server and automatically opening the url */
+                codeAction.edit = WorkspaceEdit()
+                return object : LspIntentionAction(lspServer, codeAction) {
+                    override fun invoke(project: Project, editor: Editor, psiFile: PsiFile) {
+                        BrowserUtil.open(noogleUrl)
                     }
                 }
+            }
+
+            override fun createQuickFix(lspServer: LspServer, codeAction: CodeAction): LspIntentionAction? {
+                /* discard the "open Noogle" codeAction, or it will be shown twice */
+                handleOpenNoogleCodeAction(lspServer, codeAction)?.let {return null}
+                return super.createQuickFix(lspServer, codeAction)
+            }
+
+            override fun createIntentionAction(lspServer: LspServer, codeAction: CodeAction): LspIntentionAction? {
+                handleOpenNoogleCodeAction(lspServer, codeAction)?.let {return it}
                 return super.createIntentionAction(lspServer, codeAction)
             }
         }


### PR DESCRIPTION
Follow up to #100 

The nixd noogle.dev workaround did not work in case of syntax errors in the nix file, in that case, the LSP client would also try to create a quickfix, resolve the original code action and open a new browser tab.

Applying the workaround in both `createQuickFix` and `createIntentionAction` made the "Open Noogle documentation" option appear twice. I tried disabling it in `createQuickFix` but it would also disable it in `createIntentionAction`, so I choose to discard it instead.

Tested with this (invalid) nix file
```nix
lib.getExe;
```