### PR TITLE
Run formatter from file directoy for `nix fmt` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Support `nix fmt` as external formatter ([#102](https://github.com/NixOS/nix-idea/pull/102))
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/org/nixos/idea/format/NixExternalFormatter.java
+++ b/src/main/java/org/nixos/idea/format/NixExternalFormatter.java
@@ -60,6 +60,10 @@ public final class NixExternalFormatter extends AsyncDocumentFormattingService {
         List<String> argv = ParametersListUtil.parse(command, false, true);
         var commandLine = new GeneralCommandLine(argv);
 
+        if (nixSettings.isFormatCommandRunInFileDirectory()) {
+            commandLine.setWorkDirectory(ioFile.getParent());
+        }
+
         return new FormattingTask() {
             private @Nullable OSProcessHandler handler;
             private boolean canceled;

--- a/src/main/java/org/nixos/idea/settings/NixExternalFormatterSettings.kt
+++ b/src/main/java/org/nixos/idea/settings/NixExternalFormatterSettings.kt
@@ -21,12 +21,14 @@ class NixExternalFormatterSettings : SimplePersistentStateComponent<NixExternalF
         var enabled by property(false)
         var command by string()
         var history: Deque<String> by property(ArrayDeque(), { it.isEmpty() })
+        var runInFileDirectory by property(false)
     }
 
     var isFormatEnabled: Boolean by delegate(State::enabled)
     var formatCommand: String by delegate(State::command, State::history)
     val commandHistory: Collection<String>
         get() = Collections.unmodifiableCollection(state.history)
+    var isFormatCommandRunInFileDirectory: Boolean by delegate(State::runInFileDirectory)
 
     companion object {
         @JvmStatic

--- a/src/main/java/org/nixos/idea/settings/ui/NixLangSettingsConfigurable.kt
+++ b/src/main/java/org/nixos/idea/settings/ui/NixLangSettingsConfigurable.kt
@@ -50,6 +50,11 @@ class NixLangSettingsConfigurable :
                             it.text.isNullOrBlank()
                         }
                 }
+                row() {
+                    checkBox("Run formatter in file's parent directory")
+                        .bindSelected(settings::isFormatCommandRunInFileDirectory)
+                        .comment("<html>Required for <b>nix fmt</b> to work.</html>")
+                }
             }.enabledIf(enabledCheckBox.selected)
         }
     }
@@ -64,5 +69,9 @@ private val BUILTIN_SUGGESTIONS: List<CommandSuggestionsPopup.Suggestion> = list
     CommandSuggestionsPopup.Suggestion.builtin(
         "<html>Use <b>nixpkgs-fmt</b> from nixpkgs</html>",
         "nix --extra-experimental-features \"nix-command flakes\" run nixpkgs#nixpkgs-fmt"
+    ),
+    CommandSuggestionsPopup.Suggestion.builtin(
+        "<html>Use <b>nix fmt</b> from flake.nix</html>",
+        "nix --extra-experimental-features \"nix-command flakes\" fmt"
     )
 )


### PR DESCRIPTION
fixes #97 using suggested implementation

* Add an option to Run formatter in file's parent directory. ( disabled by default )
* Add a `nix fmt` suggestion for the format command


<img width="978" height="258" alt="image" src="https://github.com/user-attachments/assets/d38d3c50-a80f-463c-bcb2-c855a4649421" />


