### PR TITLE
Add initial first-class support for nix fmt

### DIFF
--- a/src/main/java/org/nixos/idea/format/NixExternalFormatter.java
+++ b/src/main/java/org/nixos/idea/format/NixExternalFormatter.java
@@ -8,6 +8,9 @@ import com.intellij.execution.process.ProcessEvent;
 import com.intellij.formatting.service.AsyncDocumentFormattingService;
 import com.intellij.formatting.service.AsyncFormattingRequest;
 import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.execution.ParametersListUtil;
 import org.jetbrains.annotations.NotNull;
@@ -16,13 +19,16 @@ import org.nixos.idea.file.NixFile;
 import org.nixos.idea.lang.NixLanguage;
 import org.nixos.idea.settings.NixExternalFormatterSettings;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public final class NixExternalFormatter extends AsyncDocumentFormattingService {
 
@@ -43,25 +49,47 @@ public final class NixExternalFormatter extends AsyncDocumentFormattingService {
 
     @Override
     public boolean canFormat(@NotNull PsiFile psiFile) {
+        // When using `nix fmt` with `treefmt`,
+        // we may ideally support detecting which files are supported by the formatter,
+        // but currently we are only formatting `*.nix` files.
         return psiFile instanceof NixFile;
     }
 
     @Override
     protected @Nullable FormattingTask createFormattingTask(@NotNull AsyncFormattingRequest request) {
-        NixExternalFormatterSettings nixSettings = NixExternalFormatterSettings.getInstance();
-        if (!nixSettings.isFormatEnabled()) {
+        NixExternalFormatterSettings formatterSettings = NixExternalFormatterSettings.getInstance();
+        if (!formatterSettings.isEnabled()) {
             return null;
         }
 
-        var ioFile = request.getIOFile();
+        File ioFile = request.getIOFile();
         if (ioFile == null) return null;
+        Path ioPath = ioFile.toPath();
 
-        var command = nixSettings.getFormatCommand();
-        List<String> argv = ParametersListUtil.parse(command, false, true);
-        var commandLine = new GeneralCommandLine(argv);
+        // `getIOFile()` returns the file backing the document when it is a local file,
+        // and a temporary copy otherwise (this check mirrors the platform's logic).
+        VirtualFile virtualFile = request.getContext().getVirtualFile();
+        boolean formatsBackingFile = virtualFile != null
+                && virtualFile.isInLocalFileSystem()
+                && ioPath.equals(virtualFile.getFileSystem().getNioPath(virtualFile));
 
-        if (nixSettings.isFormatCommandRunInFileDirectory()) {
-            commandLine.setWorkDirectory(ioFile.getParent());
+        Strategy strategy = switch (formatterSettings.getStrategy()) {
+            case NIX_FMT -> new Strategy.NixFmtStrategy();
+            case CUSTOM_COMMAND -> new Strategy.CustomCommandStrategy(formatterSettings);
+        };
+
+        boolean useStdIo = strategy.useStdIo();
+        var commandLine = new GeneralCommandLine(strategy.command(ioPath));
+        // Not sure if using UTF-8 is technically correct.
+        // Should we use the encoding of the file, the shell, or neither?
+        commandLine.withCharset(StandardCharsets.UTF_8);
+        // If we don't use stdout, treat it the same as stderr.
+        commandLine.withRedirectErrorStream(!useStdIo);
+
+        if (strategy.runInFileDirectory()) {
+            // Might not be appropriate if `ioPath` is a temporary file,
+            // but not sure what to use instead in such cases.
+            commandLine.withWorkingDirectory(ioPath.getParent());
         }
 
         return new FormattingTask() {
@@ -70,32 +98,72 @@ public final class NixExternalFormatter extends AsyncDocumentFormattingService {
 
             @Override
             public void run() {
+                // No need to call FileDocumentManager.getInstance().saveDocument(...):
+                // The platform has already saved it before this task was created.
+
+                // Start formatter process
                 synchronized (this) {
                     if (canceled) {
                         return;
                     }
                     try {
-                        handler = new OSProcessHandler(commandLine.withCharset(StandardCharsets.UTF_8));
+                        handler = new OSProcessHandler(commandLine);
                     } catch (ExecutionException e) {
                         request.onError("NixIDEA", e.getMessage());
                         return;
                     }
                 }
+                // Configure output handling
                 handler.addProcessListener(new CapturingProcessAdapter() {
                     @Override
                     public void processTerminated(@NotNull ProcessEvent event) {
                         int exitCode = event.getExitCode();
-                        if (exitCode == 0) {
-                            request.onTextReady(getOutput().getStdout());
+                        if (useStdIo) {
+                            if (exitCode == 0) {
+                                request.onTextReady(getOutput().getStdout());
+                            } else {
+                                request.onError("NixIDEA", getOutput().getStderr());
+                            }
                         } else {
-                            request.onError("NixIDEA", getOutput().getStderr());
+                            if (formatsBackingFile) {
+                                // The formatter may have modified the file backing the document in place,
+                                // even if it failed or the request was canceled and the process got killed.
+                                // Let the VFS pick up any external change.
+                                // Passing the new text to onTextReady() instead would modify
+                                // the document in parallel to the file and could trigger the
+                                // "File Cache Conflict" dialog on the next VFS refresh.
+                                VfsUtil.markDirtyAndRefresh(false, false, false, virtualFile);
+                            }
+                            if (exitCode == 0) {
+                                if (formatsBackingFile) {
+                                    request.onTextReady(null);
+                                } else {
+                                    // The formatter modified a temporary copy.
+                                    // Read the result back and apply it to the document.
+                                    // The platform wrote the copy with the file's charset,
+                                    // and Document.setText() rejects CRLF line separators, so normalize accordingly.
+                                    try {
+                                        String text = Files.readString(ioPath,
+                                                virtualFile != null ? virtualFile.getCharset() : StandardCharsets.UTF_8);
+                                        request.onTextReady(StringUtil.convertLineSeparators(text));
+                                    } catch (IOException e) {
+                                        request.onError("NixIDEA", e.getMessage());
+                                    }
+                                }
+                            } else {
+                                // Use `getStdout()` as we enabled `withRedirectErrorStream`.
+                                request.onError("NixIDEA", getOutput().getStdout());
+                            }
                         }
                     }
                 });
                 handler.startNotify();
+                // Write formatter input
                 try {
                     OutputStream processInput = handler.getProcessInput();
-                    Files.copy(ioFile.toPath(), processInput);
+                    if (useStdIo) {
+                        processInput.write(request.getDocumentText().getBytes(StandardCharsets.UTF_8));
+                    }
                     processInput.close();
                 } catch (IOException e) {
                     handler.destroyProcess();
@@ -107,6 +175,9 @@ public final class NixExternalFormatter extends AsyncDocumentFormattingService {
             public synchronized boolean cancel() {
                 canceled = true;
                 if (handler != null) {
+                    // Do not wait for the process to die: cancel() may be called on the EDT.
+                    // While this introduces the potential of a race condition,
+                    // there seems to be no good (not overly complicated) way to handle it.
                     handler.destroyProcess();
                 }
                 return true;
@@ -117,5 +188,96 @@ public final class NixExternalFormatter extends AsyncDocumentFormattingService {
                 return true;
             }
         };
+    }
+
+    private interface Strategy {
+
+        List<String> command(Path path);
+
+        boolean runInFileDirectory();
+
+        boolean useStdIo();
+
+        private static String escapePath(Strategy strategy, Path path) {
+            if (strategy.runInFileDirectory()) {
+                // Prefix with `./` to escape files starting with a hyphen (`-`).
+                return "./" + path.getFileName();
+            } else if (path.isAbsolute()) {
+                return path.toString();
+            } else {
+                return "./" + path;
+            }
+        }
+
+        final class NixFmtStrategy implements Strategy {
+
+            // In the future, we may try to detect the formatter implementation.
+            // If the executable is named `treefmt`, we may instead use the following command:
+            //
+            //   nix fmt -- --stdin -- {file-name}
+            //
+            // The current implementation restrains itself to the
+            // following convention documented by `nix fmt --help`:
+            //
+            // > Any arguments will be forwarded to the formatter.
+            // > Typically these are the files to format.
+
+            @Override
+            public List<String> command(Path path) {
+                return List.of(
+                        "nix",
+                        "--extra-experimental-features", "nix-command flakes",
+                        "fmt",
+                        // We may alternatively use two End of Options Indicators (bare `--`)
+                        // for escaping the file name,
+                        // but we don't know if the formatter complies to this convention.
+                        // (The first indicator would be for `nix fmt`, the second one for the formatter)
+                        escapePath(this, path));
+            }
+
+            @Override
+            public boolean runInFileDirectory() {
+                return true;
+            }
+
+            @Override
+            public boolean useStdIo() {
+                return false;
+            }
+        }
+
+        final class CustomCommandStrategy implements Strategy {
+            private final NixExternalFormatterSettings mySettings;
+
+            CustomCommandStrategy(NixExternalFormatterSettings settings) {
+                mySettings = settings;
+            }
+
+            @Override
+            public List<String> command(Path path) {
+                var command = mySettings.getFormatCommand();
+                List<String> argv = ParametersListUtil.parse(command, false, true);
+                return switch (mySettings.getFormatCommandInputMode()) {
+                    case STDIO -> argv;
+                    case CLI_ARGUMENT -> Stream.concat(
+                            argv.stream(),
+                            Stream.of(escapePath(this, path))
+                    ).toList();
+                };
+            }
+
+            @Override
+            public boolean runInFileDirectory() {
+                return mySettings.isFormatCommandRunInFileDirectory();
+            }
+
+            @Override
+            public boolean useStdIo() {
+                return switch (mySettings.getFormatCommandInputMode()) {
+                    case STDIO -> true;
+                    case CLI_ARGUMENT -> false;
+                };
+            }
+        }
     }
 }

--- a/src/main/java/org/nixos/idea/settings/NixExternalFormatterSettings.kt
+++ b/src/main/java/org/nixos/idea/settings/NixExternalFormatterSettings.kt
@@ -18,22 +18,61 @@ import java.util.Deque
 class NixExternalFormatterSettings : SimplePersistentStateComponent<NixExternalFormatterSettings.State>(State()) {
 
     class State : BaseState() {
+        // Common options
         var enabled by property(false)
+        var strategy by enum<Strategy>() // initialized by loadState() or noStateLoaded() for legacy purposes
+
+        // Custom command configuration
         var command by string()
-        var history: Deque<String> by property(ArrayDeque(), { it.isEmpty() })
+        var history: Deque<String> by property(ArrayDeque()) { it.isEmpty() }
+        var inputMode by enum(InputMode.STDIO)
         var runInFileDirectory by property(false)
     }
 
-    var isFormatEnabled: Boolean by delegate(State::enabled)
+    // Common options
+    var isEnabled: Boolean by delegate(State::enabled)
+    var strategy: Strategy
+        get() = state.strategy!! // never null, always set by either loadState() or noStateLoaded()
+        set(value) {
+            state.strategy = value
+        }
+
+    // Custom command configuration
     var formatCommand: String by delegate(State::command, State::history)
-    val commandHistory: Collection<String>
+    val formatCommandHistory: Collection<String>
         get() = Collections.unmodifiableCollection(state.history)
+    var formatCommandInputMode: InputMode by delegate(State::inputMode)
     var isFormatCommandRunInFileDirectory: Boolean by delegate(State::runInFileDirectory)
+
+    override fun noStateLoaded() {
+        super.noStateLoaded()
+        state.strategy = Strategy.NIX_FMT
+        // New default for `runInFileDirectory` in new installations,
+        // without changing the behavior of configurations written by older versions.
+        state.runInFileDirectory = true
+    }
+
+    override fun loadState(state: NixExternalFormatterSettings.State) {
+        super.loadState(state)
+        if (state.strategy == null) {
+            state.strategy = if (state.command.isNullOrBlank()) Strategy.NIX_FMT else Strategy.CUSTOM_COMMAND
+        }
+    }
 
     companion object {
         @JvmStatic
         fun getInstance(): NixExternalFormatterSettings {
             return ApplicationManager.getApplication().getService(NixExternalFormatterSettings::class.java)
         }
+    }
+
+    enum class Strategy {
+        NIX_FMT,
+        CUSTOM_COMMAND,
+    }
+
+    enum class InputMode {
+        STDIO,
+        CLI_ARGUMENT,
     }
 }

--- a/src/main/java/org/nixos/idea/settings/ui/NixLangSettingsConfigurable.kt
+++ b/src/main/java/org/nixos/idea/settings/ui/NixLangSettingsConfigurable.kt
@@ -4,13 +4,18 @@ import com.intellij.openapi.options.BoundSearchableConfigurable
 import com.intellij.openapi.options.Configurable
 import com.intellij.ui.RawCommandLineEditor
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBRadioButton
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.MAX_LINE_LENGTH_WORD_WRAP
+import com.intellij.ui.dsl.builder.bind
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.selected
+import com.intellij.ui.layout.and
 import org.nixos.idea.settings.NixExternalFormatterSettings
+import org.nixos.idea.settings.NixExternalFormatterSettings.InputMode
+import org.nixos.idea.settings.NixExternalFormatterSettings.Strategy
 import org.nixos.idea.settings.ui.UiDslExtensions.bindText
 import org.nixos.idea.settings.ui.UiDslExtensions.placeholderText
 import org.nixos.idea.settings.ui.UiDslExtensions.suggestionsPopup
@@ -25,37 +30,55 @@ class NixLangSettingsConfigurable :
     override fun createPanel() = panel {
         group("External Formatter", indent = false) {
             val settings = NixExternalFormatterSettings.getInstance()
-            lateinit var enabledCheckBox: Cell<JBCheckBox>
+            lateinit var formatterEnabled: Cell<JBCheckBox>
+            lateinit var customCommandEnabled: Cell<JBRadioButton>
             row {
-                enabledCheckBox = checkBox("Enable external formatter")
-                    .bindSelected(settings::isFormatEnabled)
+                formatterEnabled = checkBox("Enable external formatter")
+                    .bindSelected(settings::isEnabled)
                     .comment(
                         """
                         Format Nix files via an external formatter.
-                        Source of focused file will be passed as standard input.
                         """.trimIndent(),
                         MAX_LINE_LENGTH_WORD_WRAP
                     )
             }
             indent {
-                row("Command:") {
-                    cell(RawCommandLineEditor())
-                        .bindText(settings::formatCommand)
-                        .placeholderText("Command to execute for formatting")
-                        .suggestionsPopup(settings.commandHistory, BUILTIN_SUGGESTIONS)
-                        .align(AlignX.FILL)
-                        .validateOnReset()
-                        .validateWhenTextChanged()
-                        .warnOnInput("You have to specify the command of the formatter") {
-                            it.text.isNullOrBlank()
+                buttonsGroup {
+                    row {
+                        radioButton("<html>Use <b>nix fmt</b></html>", Strategy.NIX_FMT)
+                        customCommandEnabled = radioButton("Use custom command", Strategy.CUSTOM_COMMAND)
+                    }
+                }.bind(settings::strategy)
+                groupRowsRange(indent = false) {
+                    row("Command:") {
+                        cell(RawCommandLineEditor())
+                            .bindText(settings::formatCommand)
+                            .placeholderText("Command to execute for formatting")
+                            .suggestionsPopup(settings.formatCommandHistory, BUILTIN_SUGGESTIONS)
+                            .align(AlignX.FILL)
+                            .validateOnReset()
+                            .validateWhenTextChanged()
+                            .warnOnInput("You have to specify the command of the formatter") {
+                                it.text.isNullOrBlank()
+                            }
+                    }
+                    buttonsGroup {
+                        row {
+                            radioButton("<html>Use <code>stdin</code> and <code>stdout</code></html>", InputMode.STDIO)
+                                .comment("Source of the focused file will be passed as standard input.")
                         }
-                }
-                row() {
-                    checkBox("Run formatter in file's parent directory")
-                        .bindSelected(settings::isFormatCommandRunInFileDirectory)
-                        .comment("<html>Required for <b>nix fmt</b> to work.</html>")
-                }
-            }.enabledIf(enabledCheckBox.selected)
+                        row {
+                            radioButton("Use CLI argument", InputMode.CLI_ARGUMENT)
+                                .comment("Path of the focused file will be specified as an additional argument.")
+                        }
+                    }.bind(settings::formatCommandInputMode)
+                    row {
+                        checkBox("Run formatter in the file's parent directory")
+                            .bindSelected(settings::isFormatCommandRunInFileDirectory)
+                            .comment("Required for <b>nix fmt</b> to work.")
+                    }
+                }.visibleIf(formatterEnabled.selected and customCommandEnabled.selected)
+            }.enabledIf(formatterEnabled.selected)
         }
     }
 


### PR DESCRIPTION
This is my attempt to resolve #97.

This PR takes initial steps for first-class support of `nix fmt`, together with a new option _“Use CLI argument”_ for custom commands.

@Meallia I am mentioning you because you worked on #102, and because you also considered looking into this topic in the future. Feel free to comment if you have any suggestions, but no pressure.

## Approach and remaining problems

Unfortunately, my testing shows some problems with the current implementation. Here is my approach:

 1. Ensure the focused file is written to disk. (Already done by the platform)
 2. Call `nix fmt {path-to-file}`
 3. Call `VfsUtil.markDirtyAndRefresh` to inform IntelliJ that the file has changed

This leads to the following dialog if the user continuous to type after string the formatter:

<img width="583" height="123" alt="grafik" src="https://github.com/user-attachments/assets/52138833-75e3-430d-8577-6513acd7aeef" />

I currently see two potential solutions to address these problems:

- Rely on `treefmt`-specific command line arguments:  
  `nix fmt -- --stdin -- {path-to-file}`

- Copy the formatted file, and pass the new temporary file to the command instead of the original.
  Afterward, copy back the formatted changes from the temporary file to IntelliJ.

Not sure if there is a third viable approach.

I also noticed that the current performance is rather bad. Running the formatter from IntelliJ takes much longer then calling in from the terminal. I have not yet profiled the issue.

## Future Work

Beside the previously mentioned issues, there are some open topics which could be discussed in the future if the initial implementation has been released:

- `nix fmt` is often configured to also handle other types of files, not just `*.nix`. It might be valuable to enable the external formatter for these files as well. The main challenge would be how to figure out from the plugin which files can be formatted by the current configuration of `nix fmt`.

- IntelliJ cancels the formatting task if it takes more than 30 seconds. This can easily happen if the formatter is not yet available and has to be built (or downloaded). We should try to figure out if we can find a way around this timeout.

- When running the formatter, `stderr` is currently only shown to the user once the process returns a non-zero exit code. However, for lengthy build processes, we should try to make the progress visible to the user.

## Screenshots

Here are two screenshots of the new settings page:

<img width="1100" height="916" alt="grafik" src="https://github.com/user-attachments/assets/9ff3176e-6206-49e8-8617-070013441d3f" />
<img width="1100" height="916" alt="grafik" src="https://github.com/user-attachments/assets/0c2f9410-cacc-4b3d-88e3-e6bcdae664fa" />
