### PR TITLE
Support devenv options in devenv.nix via devenv lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Completion and documentation for devenv options in `devenv.nix` files via the `devenv lsp` language server
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/org/nixos/idea/lsp/DevenvLspServerDescriptor.kt
+++ b/src/main/java/org/nixos/idea/lsp/DevenvLspServerDescriptor.kt
@@ -1,0 +1,65 @@
+package org.nixos.idea.lsp
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonParser
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.util.ExecUtil
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.execution.ParametersListUtil
+import org.eclipse.lsp4j.ConfigurationItem
+import org.nixos.idea.file.NixFileType
+
+internal class DevenvLspServerDescriptor(project: Project, settings: NixLspSettings) :
+    NixLspServerDescriptor(project, settings, "devenv") {
+
+    override val commandString: String
+        get() = settings.devenvCommand
+
+    @Throws(ExecutionException::class)
+    override fun createCommandLine(): GeneralCommandLine {
+        // `devenv lsp` must run in the directory containing the devenv configuration
+        return super.createCommandLine().apply {
+            project.basePath?.let { withWorkDirectory(it) }
+        }
+    }
+
+    override fun isSupportedFile(file: VirtualFile): Boolean {
+        return file.fileType === NixFileType.INSTANCE && file.name == DEVENV_FILE_NAME
+    }
+
+    // nixd ignores the --config option passed by `devenv lsp` and instead requests its
+    // configuration from the client via workspace/configuration. Without a proper answer it
+    // falls back to completing NixOS options instead of devenv options.
+    override fun getWorkspaceConfiguration(item: ConfigurationItem): Any? {
+        if (item.section != null && item.section != NIXD_CONFIG_SECTION) return null
+        return nixdConfiguration
+    }
+
+    private val nixdConfiguration: JsonElement? by lazy {
+        try {
+            val argv = ParametersListUtil.parse(commandString, false, true) + PRINT_CONFIG_OPTION
+            val commandLine = GeneralCommandLine(argv)
+            project.basePath?.let { commandLine.withWorkDirectory(it) }
+            val output = ExecUtil.execAndGetOutput(commandLine, PRINT_CONFIG_TIMEOUT_MILLIS)
+            if (output.exitCode != 0 || output.isTimeout) {
+                thisLogger().warn("$commandLine failed (exit code ${output.exitCode}): ${output.stderr}")
+                null
+            } else {
+                JsonParser.parseString(output.stdout).asJsonObject.get(NIXD_CONFIG_SECTION)
+            }
+        } catch (e: Exception) {
+            thisLogger().warn("Failed to obtain nixd configuration from $commandString", e)
+            null
+        }
+    }
+
+    companion object {
+        const val DEVENV_FILE_NAME = "devenv.nix"
+        private const val NIXD_CONFIG_SECTION = "nixd"
+        private const val PRINT_CONFIG_OPTION = "--print-config"
+        private const val PRINT_CONFIG_TIMEOUT_MILLIS = 30_000
+    }
+}

--- a/src/main/java/org/nixos/idea/lsp/NixLspServerDescriptor.kt
+++ b/src/main/java/org/nixos/idea/lsp/NixLspServerDescriptor.kt
@@ -18,17 +18,24 @@ import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.nixos.idea.file.NixFileType
 
-internal class NixLspServerDescriptor(project: Project, private var settings: NixLspSettings) :
-    ProjectWideLspServerDescriptor(project, "Nix") {
+internal open class NixLspServerDescriptor @JvmOverloads constructor(
+    project: Project,
+    protected val settings: NixLspSettings,
+    presentableName: String = "Nix",
+) : ProjectWideLspServerDescriptor(project, presentableName) {
+
+    protected open val commandString: String
+        get() = settings.command
 
     @Throws(ExecutionException::class)
     override fun createCommandLine(): GeneralCommandLine {
-        val argv = ParametersListUtil.parse(settings.command, false, true)
+        val argv = ParametersListUtil.parse(commandString, false, true)
         return GeneralCommandLine(argv)
     }
 
     override fun isSupportedFile(file: VirtualFile): Boolean {
-        return file.fileType === NixFileType.INSTANCE
+        return file.fileType === NixFileType.INSTANCE &&
+                !(settings.isDevenvEnabled && file.name == DevenvLspServerDescriptor.DEVENV_FILE_NAME)
     }
 
     override val lspCustomization: LspCustomization = object : LspCustomization() {

--- a/src/main/java/org/nixos/idea/lsp/NixLspServerSupportProvider.java
+++ b/src/main/java/org/nixos/idea/lsp/NixLspServerSupportProvider.java
@@ -16,7 +16,10 @@ public final class NixLspServerSupportProvider implements LspServerSupportProvid
     public void fileOpened(@NotNull Project project, @NotNull VirtualFile virtualFile, @NotNull LspServerStarter lspServerStarter) {
         if (virtualFile.getFileType() == NixFileType.INSTANCE) {
             NixLspSettings settings = NixLspSettings.getInstance();
-            if (settings.isEnabled()) {
+            if (settings.isDevenvEnabled()
+                    && DevenvLspServerDescriptor.DEVENV_FILE_NAME.equals(virtualFile.getName())) {
+                lspServerStarter.ensureServerStarted(new DevenvLspServerDescriptor(project, settings));
+            } else if (settings.isEnabled()) {
                 lspServerStarter.ensureServerStarted(new NixLspServerDescriptor(project, settings));
             }
         }

--- a/src/main/java/org/nixos/idea/lsp/NixLspSettings.kt
+++ b/src/main/java/org/nixos/idea/lsp/NixLspSettings.kt
@@ -19,6 +19,9 @@ class NixLspSettings : SimplePersistentStateComponent<NixLspSettings.State>(Stat
         var enabled by property(false)
         var command by string()
         var history: Deque<String> by property(ArrayDeque(), { it.isEmpty() })
+        var devenvEnabled by property(false)
+        var devenvCommand by string(DEFAULT_DEVENV_COMMAND)
+        var devenvHistory: Deque<String> by property(ArrayDeque(), { it.isEmpty() })
     }
 
     var isEnabled: Boolean by delegate(State::enabled)
@@ -26,7 +29,15 @@ class NixLspSettings : SimplePersistentStateComponent<NixLspSettings.State>(Stat
     val commandHistory: Collection<String>
         get() = Collections.unmodifiableCollection(state.history)
 
+    @get:JvmName("isDevenvEnabled")
+    var isDevenvEnabled: Boolean by delegate(State::devenvEnabled)
+    var devenvCommand: String by delegate(State::devenvCommand, State::devenvHistory)
+    val devenvCommandHistory: Collection<String>
+        get() = Collections.unmodifiableCollection(state.devenvHistory)
+
     companion object {
+        const val DEFAULT_DEVENV_COMMAND = "devenv lsp"
+
         @JvmStatic
         fun getInstance(): NixLspSettings {
             return ApplicationManager.getApplication().getService(NixLspSettings::class.java)

--- a/src/main/java/org/nixos/idea/lsp/NixLspSettingsConfigurable.kt
+++ b/src/main/java/org/nixos/idea/lsp/NixLspSettingsConfigurable.kt
@@ -44,6 +44,25 @@ class NixLspSettingsConfigurable :
                     }
             }
         }.enabledIf(enabledCheckBox.selected)
+        lateinit var devenvCheckBox: Cell<JBCheckBox>
+        row {
+            devenvCheckBox = checkBox("Enable devenv.sh integration for devenv.nix files")
+                .bindSelected(settings::isDevenvEnabled)
+        }
+        group("Devenv Language Server Configuration") {
+            row("Command:") {
+                cell(RawCommandLineEditor())
+                    .bindText(settings::devenvCommand)
+                    .placeholderText("Command to start devenv Language Server")
+                    .suggestionsPopup(settings.devenvCommandHistory, DEVENV_SUGGESTIONS)
+                    .align(AlignX.FILL)
+                    .validateOnReset()
+                    .validateWhenTextChanged()
+                    .warnOnInput("You have to specify the command to start the Language Server") {
+                        it.text.isNullOrBlank()
+                    }
+            }
+        }.enabledIf(devenvCheckBox.selected)
     }
 
     @Suppress("UnstableApiUsage")
@@ -64,5 +83,12 @@ private val BUILTIN_SUGGESTIONS: List<CommandSuggestionsPopup.Suggestion> = list
     CommandSuggestionsPopup.Suggestion.builtin(
         "<html>Use <b>nixd</b> from nixpkgs</html>",
         "nix --extra-experimental-features \"nix-command flakes\" run nixpkgs#nixd"
+    )
+)
+
+private val DEVENV_SUGGESTIONS: List<CommandSuggestionsPopup.Suggestion> = listOf(
+    CommandSuggestionsPopup.Suggestion.builtin(
+        "<html>Use <b>devenv lsp</b> (requires devenv on PATH)</html>",
+        "devenv lsp"
     )
 )


### PR DESCRIPTION
Adds a second, opt-in LSP server that runs `devenv lsp` (nixd-based) for files named devenv.nix, providing completion and documentation for [devenv](https://devenv.sh/) options. Other .nix files keep using the generic language server.

nixd 2.9.1 ignores the --config option passed by `devenv lsp` and requests its configuration via workspace/configuration instead. The devenv server descriptor answers that request with the output of `devenv lsp --print-config`; without this, nixd silently completes NixOS options instead of devenv options.